### PR TITLE
internal: Updates to generated decision logs and non-OPA error wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ The `input` value defined for your policy will resemble the JSON below:
   },
   "parsed_body":{"firstname": "Charlie", "lastname": "Opa"},
   "parsed_path":["people"],
-  "parsed_query": {"lang": ["en"]}
+  "parsed_query": {"lang": ["en"]},
+  "truncated_body": false
 }
 ```
 
@@ -379,6 +380,10 @@ allow {
    input.parsed_body.lastname == "Opa"
 }
 ```
+
+The `truncated_body` field in the input represents if the HTTP request body is truncated. The body is considered to be
+truncated, if the value of the `Content-Length` header exceeds the size of the request body.
+
 
 ## Example Policy with Object Response
 


### PR DESCRIPTION
This commit updates the server handler to create a decision ID and
a Metrics object on start-up that can be later included in the decision log.
This ensures that the decision log will have an ID and the server handler time
even in error scenarios.

This change also wraps non-OPA errors to ensure they are properly
serialized.

Fixes open-policy-agent/opa#2591, Fixes open-policy-agent/opa#2592,
Fixes open-policy-agent/opa#2593, Fixes open-policy-agent/opa#2594

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>