### PR TITLE
Makefile: Use the plugin version to build releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 RELEASE_BUILD_IMAGE := golang:$(GOVERSION)
 
-RELEASE_DIR ?= _release/$(VERSION_OPA)
+RELEASE_DIR ?= _release/$(VERSION)
 
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
@@ -131,7 +131,7 @@ release:
 		-v $(PWD)/$(RELEASE_DIR):/$(RELEASE_DIR) \
 		-v $(PWD):/_src \
 		$(RELEASE_BUILD_IMAGE) \
-		/_src/build/build-release.sh --version=$(VERSION_OPA) --output-dir=/$(RELEASE_DIR) --source-url=/_src
+		/_src/build/build-release.sh --version=$(VERSION) --output-dir=/$(RELEASE_DIR) --source-url=/_src
 
 
 .PHONY: release-build-linux


### PR DESCRIPTION
Earlier we used only the OPA version to create a GH release and
build the release binaries. We did not create a new GH release when
changes we made to the plugin itself.

This change updates the release target to use the plugin version
instead of only the OPA version to checkout and build binaries.
This will allow us to create releases for the plugin revisions.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>