### PR TITLE
.github: Change fetch-depth in the GHA checkout step

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set TAG_NAME in Environment
         # Subsequent jobs will be have the computed tag name


### PR DESCRIPTION
Earlier the checkout step of the post-tag workflow
used the default fetch-depth=1 which would only fetch a
single commit. This would result in an incorrect calculation
of the number of commits from the last OPA revendoring.

This change sets fetch-depth=0 to fetch all history to correct
this issue.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>