### PR TITLE
.github: Update post tag workflow to use env files

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Set TAG_NAME in Environment
         # Subsequent jobs will be have the computed tag name
-        run: echo ::set-env name=TAG_NAME::"${GITHUB_REF##*/}"
+        run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Build Release Binaries
         run: make release


### PR DESCRIPTION
The post tag workflow used the `set-env` command to
set the TAG_NAME env variable. The `set-env` command is
now disabled. This change updates the worklow to remove
usage of the `set-env` command to use environment files
instead.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>