### PR TITLE
README.md: update JWT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,37 +436,17 @@ http_filters:
 This will result in something like the following dictionary being added to `input.attributes` (some common fields have
 been excluded for brevity):
 ```ruby
-"metadata_context": {
-  "filter_metadata": {
-    "envoy.filters.http.jwt_authn": {
-      "fields": {
+  "metadata_context": {
+    "filter_metadata": {
+      "envoy.filters.http.jwt_authn": {
         "verified_jwt": {
-          "Kind": {
-            "StructValue": {
-              "fields": {
-                "email": {
-                  "Kind": {
-                    "StringValue": "alice@example.com"
-                  }
-                },
-                "exp": {
-                  "Kind": {
-                    "NumberValue": 1569026124
-                  }
-                },
-                "name": {
-                  "Kind": {
-                    "StringValue": "Alice"
-                  }
-                }
-              }
-            }
-          }
+          "email": "alice@example.com",
+          "exp": 1569026124,
+          "name": "Alice"
         }
       }
     }
   }
-}
 ```
 
 ### Example OPA Policy
@@ -474,13 +454,7 @@ been excluded for brevity):
 This JWT data can be accessed in OPA policy like this:
 
 ```ruby
-jwt_payload = _value {
-    verified_jwt := input.attributes.metadata_context.filter_metadata["envoy.filters.http.jwt_authn"]["fields"]["verified_jwt"]
-    _value := {
-        "name": verified_jwt["Kind"]["StructValue"]["fields"]["name"]["Kind"]["StringValue"],
-        "email": verified_jwt["Kind"]["StructValue"]["fields"]["email"]["Kind"]["StringValue"]
-    }
-}
+jwt_payload = input.attributes.metadata_context.filter_metadata["envoy.filters.http.jwt_authn"].verified_jwt
 
 allow {
   jwt_payload.email == "alice@example.com"


### PR DESCRIPTION
Some day, we've updated our vendored protobuf files by updating go-control-plane,
and it has pulled in a change to the "well-known" type google.protobuf.Struct that
made it play nice with encoding/json from the stdlib.

This is a recent decision log entry (abbreviated) that shows that dynamic metadata
no longer looks like it did in oct 2019.

    {
      "decision_id": "0824f36e-8e1e-41e4-a692-b71fd72ee3db",
      "input": {
        "attributes": {
          "destination": {
            "address": {
              "Address": {
                "SocketAddress": {
                  "PortSpecifier": {
                    "PortValue": 51051
                  },
                  "address": "127.0.0.1"
                }
              }
            }
          },
          "metadata_context": {
            "filter_metadata": {
              "envoy.filters.http.jwt_authn": {
                "verified_jwt": {
                  "at_hash": "upgSTpYk9xI07B4MXcJwcg",
                  "aud": "example-app",
                  "email": "kilgore@kilgore.trout",
                  "email_verified": true,
                  "exp": 1605957182,
                  "groups": [
                    "authors"
                  ],
                  "iat": 1605870782,
                  "iss": "http://127.0.0.1:5556/dex",
                  "name": "Kilgore Trout",
                  "sub": "Cg0wLTM4NS0yODA4OS0wEgRtb2Nr"
                }
              }
            }
          },
          "request": {
            "http": {
              "headers": {
                ":authority": "127.0.0.1:51051",
                ":method": "GET",
                ":path": "/foobar",
                "accept": "*/*",

Signed-off-by: Stephan Renatus <stephan@styra.com>