### PR TITLE
actions: fix e2e test, add it to pull-request workflow

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -63,36 +63,26 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Run End-to-End Test
+      - name: Build docker image
+        run: make image tag-latest
+
+      - name: Setup kind/istio
         run: |
-          KIND_VERSION=0.4.0
-          ISTIO_VERSION=1.5.0
-
-          # Download and install kind
-          curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
-
-          # Create kind cluster
-          if [ -z $(kind get clusters) ]; then
-            kind create cluster
-          fi
-          export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-
-          # Download and install kubectl
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
-
-          # Download and install Istio
-          curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh - && \
-            mv istio-${ISTIO_VERSION} /tmp && \
-            cd /tmp/istio-${ISTIO_VERSION} && \
-            bin/istioctl install -y --set profile=demo
-          kubectl -n istio-system wait --for=condition=available --timeout=600s --all deployment
+          # install kind, kubectl, istio
+          make test-cluster
 
           # Install bats
           sudo apt-get update -y
           sudo apt-get install -y bats
 
-          # Run the test
-          make update-istio-quickstart-version && make test-e2e
+          # Prepare quick_start.yaml
+          make update-istio-quickstart-version
 
-          # Delete the cluster
-          kind delete cluster
+          # Make docker image available to k8s
+          kind load docker-image openpolicyagent/opa:latest-istio
+
+      - name: Run e2e tests
+        run: make test-e2e
+
+      - name: Cleanup
+        run: kind delete cluster

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -35,3 +35,34 @@ jobs:
       - name: Golang Style and Lint Check
         run: make check
         timeout-minutes: 15
+
+  e2e:
+    name: End-to-End Test
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build docker image
+        run: make image tag-latest
+
+      - name: Setup kind/istio
+        run: |
+          # install kind, kubectl, istio
+          make test-cluster
+
+          # Install bats
+          sudo apt-get update -y
+          sudo apt-get install -y bats
+
+          # Prepare quick_start.yaml
+          make update-istio-quickstart-version
+
+          # Make docker image available to k8s
+          kind load docker-image openpolicyagent/opa:latest-istio
+
+      - name: Run e2e tests
+        run: make test-e2e
+
+      - name: Cleanup
+        run: kind delete cluster

--- a/build/install-istio-with-kind.sh
+++ b/build/install-istio-with-kind.sh
@@ -6,7 +6,7 @@ set -x
 
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
-KIND_VERSION=0.4.0
+KIND_VERSION=0.9.0
 ISTIO_VERSION=1.7.0
 
 # Download and install kind
@@ -17,15 +17,16 @@ if [ -z $(kind get clusters) ]; then
     kind create cluster
 fi
 
-# Get kubeconfig
-export KUBECONFIG="$(kind get kubeconfig-path --name=kind)"
-
 # Download and install kubectl
 curl -LO \
 https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/${GOOS}/${GOARCH}/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
 
+# Use kind cluster
+kubectl cluster-info --context kind-kind
+
 # Download and install Istio
 curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh - && mv istio-${ISTIO_VERSION} /tmp
-cd /tmp/istio-${ISTIO_VERSION}
+pushd /tmp/istio-${ISTIO_VERSION}
 bin/istioctl install -y --set profile=demo
+popd
 kubectl -n istio-system wait --for=condition=available --timeout=600s --all deployment


### PR DESCRIPTION
Also updates kind to 0.9.0, required for Istio 1.7.0.
(Oversight of #217)

👉 Here's an example run of this PR: https://github.com/open-policy-agent/opa-envoy-plugin/runs/1453090996?check_suite_focus=true#step:4:211

⏱️ Just short of 5 minutes. Sounds OK to me. Let's try to roll with this in the pull-request workflow for a while.