### PR TITLE
workflow: use docker-env for building image (to ensure golang version)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build docker image
-        run: make image tag-latest
+        run: make release-local image-quick tag-latest
 
       - name: Setup kind/istio
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
-# Copyright 2018 The OPA Authors. All rights reserved.
+# Copyright 2019 The OPA Authors.  All rights reserved.
 # Use of this source code is governed by an Apache2
 # license that can be found in the LICENSE file.
 
-FROM gcr.io/distroless/base
+ARG BASE
+
+FROM ${BASE}
+
+# Any non-zero number will do, and unfortunately a named user will not, as k8s
+# pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958. Make root (uid 0) when
+# not specified.
+ARG USER=0
 
 MAINTAINER Ashutosh Narkar  <anarkar4387@gmail.com>
 
-WORKDIR /app
+# Hack.. https://github.com/moby/moby/issues/37965
+# _Something_ needs to be between the two COPY steps.
+USER ${USER}
 
-COPY opa_envoy_linux_GOARCH /app
+ARG BIN_DIR=.
+COPY ${BIN_DIR}/opa_envoy_linux_amd64 /opa
 
-ENTRYPOINT ["./opa_envoy_linux_GOARCH"]
-
+ENTRYPOINT ["/opa"]
 CMD ["run"]


### PR DESCRIPTION
Before, the `image` would invoke `build-linux`, and that wouldn't guarantee the
version of golang used for building.

Now, the `image` target goes through a round of `make release` to ensure just
that.

As a consequence, we'll build windows and darwin binaries where we don't need
them, but let's see if the time wasted is problematic at all.

To verify that this does what it's supposed to do, I've overridden the VERSION
makefile variable, and ran `make image`. The resulting container reports:

    $ docker run openpolicyagent/opa:"0.24.0-envoy-11" version
    Version: 0.24.0-envoy-11
    Build Commit: e4f19267
    Build Timestamp: 2020-11-30T10:40:36Z
    Build Hostname: 6bec0a11f7e7
    Go Version: go1.15.2

Fixes https://github.com/open-policy-agent/opa/issues/2942.

----
⚠️ There's one thing to note here -- actually running the service built using that Golang version means it'll be **less tolerant towards TLS certs than it was before**. In #217, I've run into this locally, so the `examples/istio/quick_start.yaml` certs have been adapted, but there hasn't been a release of opa-envoy-plugin using Go 1.15.x until we ship **this change**.

For more details about what's going on, [please refer to the release notes](https://golang.org/doc/go1.15#commonname):
> The deprecated, legacy behavior of treating the `CommonName` field on X.509 certificates as a host name when no `Subject Alternative Names` are present is now disabled by default. It can be temporarily re-enabled by adding the value `x509ignoreCN=0` to the `GODEBUG` environment variable.
>
> Note that if the `CommonName` is an invalid host name, it's always ignored, regardless of `GODEBUG `settings. Invalid names include those with any characters other than letters, digits, hyphens and underscores, and those with empty labels or trailing dots.

