### PR TITLE
internal: fix parsed path url-unescaping

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -693,12 +693,7 @@ func getRevision(ctx context.Context, store storage.Store, txn storage.Transacti
 }
 
 func getParsedPathAndQuery(path string) ([]interface{}, map[string]interface{}, error) {
-	unescapedPath, err := url.PathUnescape(path)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	parsedURL, err := url.Parse(unescapedPath)
+	parsedURL, err := url.Parse(path)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1981,9 +1981,9 @@ func TestParsedPathAndQuery(t *testing.T) {
 			map[string]interface{}{"a": []interface{}{"1"}, "b": []interface{}{"2"}},
 		},
 		{
-			createExtReqWithPath("%2Fmy%2Ftest%2Fpath%3Fa%3D1%26a%3D2"),
+			createExtReqWithPath("/my/test/path?a=1&a=new%0aline"),
 			[]interface{}{"my", "test", "path"},
-			map[string]interface{}{"a": []interface{}{"1", "2"}},
+			map[string]interface{}{"a": []interface{}{"1", "new\nline"}},
 		},
 	}
 

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1985,6 +1985,11 @@ func TestParsedPathAndQuery(t *testing.T) {
 			[]interface{}{"my", "test", "path"},
 			map[string]interface{}{"a": []interface{}{"1", "new\nline"}},
 		},
+		{
+			createExtReqWithPath("%2Fmy%2Ftest%2Fpath?a=1&a=new%0aline"),
+			[]interface{}{"my", "test", "path"},
+			map[string]interface{}{"a": []interface{}{"1", "new\nline"}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Re-vived #175  to fix https://github.com/open-policy-agent/opa/issues/3004

Original PR message by @vetyy below:

------

Hello,

I found a problem with parsing path and query parameters.

The original test is actually invalid and is escaping reserved characters '=', '?' and '&' as per (https://tools.ietf.org/html/rfc3986#section-2.2).

If I change test to include a '\n' character in query parameter it will be first unescaped by url.PathUnescape and then again using url.Parse that will result in error "net/url: invalid control character in URL".

So there is no need to explicitly unescape path as url.Parse handles that internally.

I updated the code and test to be valid and I also tested in our own OPA deployment.

Thanks,
Matej