### PR TITLE
README, test-e2e: bump Istio to 1.8.x

### DIFF
--- a/build/install-istio-with-kind.sh
+++ b/build/install-istio-with-kind.sh
@@ -7,7 +7,7 @@ set -x
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
 KIND_VERSION=0.9.0
-ISTIO_VERSION=1.7.0
+ISTIO_VERSION=1.8.2
 
 # Download and install kind
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${GOOS}-${GOARCH} --output kind && chmod +x kind && sudo mv kind /usr/local/bin/

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -20,7 +20,7 @@ availability) in order to perform the authorization check.
 
 ## Quick Start
 
-This section assumes you are testing with Istio v1.7.0 or later.
+This section assumes you are testing with Istio v1.8.0 or later.
 
 This section assumes you have Istio deployed on top of Kubernetes. See Istio's [Quick Start](https://istio.io/docs/setup/kubernetes/install/kubernetes/) page to get started.
 


### PR DESCRIPTION
👉  https://istio.io/latest/news/support/announcing-1.7-eol/

Istio 1.7.x goes EOL on Feb 19th. So, merging this isn't urgent, but if we want to bump, here it is.`test-e2e` run locally passed ✅ 