### PR TITLE
internal: Include revisions of multiple bundles in decision log event

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/logs"
 	"github.com/open-policy-agent/opa/storage"
@@ -299,6 +300,99 @@ func TestCheckAllowWithLogger(t *testing.T) {
 			t.Fatalf("Expected non-zero metric for %v", key)
 		}
 	}
+}
+
+func TestGetRevisionLegacy(t *testing.T) {
+	store := inmem.New()
+	ctx := context.Background()
+
+	result := evalResult{}
+
+	tb := bundle.Manifest{
+		Revision: "abc123",
+		Roots:    &[]string{"/a/b", "/a/c"},
+	}
+
+	// write a "legacy" manifest
+	err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if err := bundle.LegacyWriteManifestToStore(ctx, store, txn, tb); err != nil {
+			t.Fatalf("Failed to write manifest to store: %s", err)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error finishing transaction: %s", err)
+	}
+
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+	err = getRevision(ctx, store, txn, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "abc123"
+	if result.revision != "abc123" {
+		t.Fatalf("Expected revision %v but got %v", expected, result.revision)
+	}
+
+	if len(result.revisions) != 0 {
+		t.Fatal("Unexpected multiple bundles")
+	}
+}
+
+func TestGetRevisionMulti(t *testing.T) {
+	store := inmem.New()
+	ctx := context.Background()
+
+	result := evalResult{}
+
+	bundles := map[string]bundle.Manifest{
+		"bundle1": {
+			Revision: "abc123",
+			Roots:    &[]string{"/a/b", "/a/c"},
+		},
+		"bundle2": {
+			Revision: "def123",
+			Roots:    &[]string{"/x/y", "/z"},
+		},
+	}
+
+	// write bundles
+	for name, manifest := range bundles {
+		err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+			err := bundle.WriteManifestToStore(ctx, store, txn, name, manifest)
+			if err != nil {
+				t.Fatalf("Failed to write manifest to store: %s", err)
+			}
+			return err
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error finishing transaction: %s", err)
+		}
+	}
+
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+	err := getRevision(ctx, store, txn, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.revisions) != 2 {
+		t.Fatalf("Expected two bundles but got %v\n", len(result.revisions))
+	}
+
+	expected := map[string]string{"bundle1": "abc123", "bundle2": "def123"}
+	if !reflect.DeepEqual(result.revisions, expected) {
+		t.Fatalf("Expected result: %v, got: %v", expected, result.revisions)
+	}
+
+	if result.revision != "" {
+		t.Fatalf("Unexpected revision %v", result.revision)
+	}
+
 }
 
 func TestCheckDeny(t *testing.T) {


### PR DESCRIPTION
Earlier the decision log events generated by the plugin did not set the
revision in cases where multiple bundles were configured. This change
includes these revisions in the log event and also adds a deprecation label
to the "revision" field of the eval result.

Fixes open-policy-agent/opa#3141

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>