### PR TITLE
Update opa-istio example to allow control of the injection policy at the pod level.

### DIFF
--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -90,6 +90,18 @@ IP/port of the Istio Ingress gateway.
     curl --user bob:password -i http://$GATEWAY_URL/productpage
     curl --user bob:password -i http://$GATEWAY_URL/api/v1/products
     ```
+## Controlling the injection policy at the pod level
+
+If you want to control the injection policy at the pod level, set the `sidecar.opa-istio.io/inject` label to `false` on the pod.
+An example of the updated admission controller configuration is shown below:
+```yaml
+objectSelector:
+  matchExpressions:
+  - key: sidecar.opa-istio.io/inject
+    operator: NotIn
+    values:
+    - "false"
+```
 
 ## Example Bundle Configuration
 


### PR DESCRIPTION
Did you not need to update this example?

I thought it would be more helpful to developers if it was explicitly stated in the example, because in my environment, I need to control the injection policy at the pod level.
