### PR TITLE
add log messages for unsupported/missing content-type

### DIFF
--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -160,7 +160,11 @@ func getParsedBody(logEntry *logrus.Entry, headers map[string]string, body strin
 			if !known {
 				return nil, false, nil
 			}
+		} else {
+			logEntry.Debugf("content-type: %s parsing not supported", val)
 		}
+	} else {
+		logEntry.Debug("no content-type header supplied, performing no body parsing")
 	}
 
 	return data, false, nil


### PR DESCRIPTION
Signed-off-by: Justin Ely <justincely@gmail.com>

Adds log messages to help users debug if they aren't seeing the `parsed_body` field populated correctly.  

Closes https://github.com/open-policy-agent/opa/issues/3566