### PR TITLE
deps: bump OPA to v0.29.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To deploy OPA-Envoy include the following container in your Kubernetes Deploymen
 
 ```yaml
 containers:
-- image: openpolicyagent/opa:0.29.1-envoy
+- image: openpolicyagent/opa:0.29.4-envoy
   imagePullPolicy: IfNotPresent
   name: opa-envoy
   volumeMounts:

--- a/examples/istio/quick_start.yaml
+++ b/examples/istio/quick_start.yaml
@@ -187,7 +187,7 @@ data:
     }]
 
     opa_container = {
-      "image": "openpolicyagent/opa:0.29.1-istio",
+      "image": "openpolicyagent/opa:0.29.4-istio",
       "name": "opa-istio",
       "args": [
         "run",
@@ -267,7 +267,7 @@ spec:
       name: admission-controller
     spec:
       containers:
-        - image: openpolicyagent/opa:0.29.1
+        - image: openpolicyagent/opa:0.29.4
           name: opa
           ports:
           - containerPort: 443

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.7
-	github.com/open-policy-agent/opa v0.29.1
+	github.com/open-policy-agent/opa v0.29.4
 	github.com/peterh/liner v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -573,6 +573,8 @@ github.com/open-policy-agent/opa v0.29.0 h1:KXurLW0/Z5j7Dn/Uzoz6f8eyXHT4CIskM21y
 github.com/open-policy-agent/opa v0.29.0/go.mod h1:ZCOTD3yyFR8JvF8ETdWdiSPn9WcF1dXeQWOv7VoPorU=
 github.com/open-policy-agent/opa v0.29.1 h1:2aAGUtdTRgPF8eh0m9Wg4CoQtSbp/CcoZD7fejSX6xU=
 github.com/open-policy-agent/opa v0.29.1/go.mod h1:ZCOTD3yyFR8JvF8ETdWdiSPn9WcF1dXeQWOv7VoPorU=
+github.com/open-policy-agent/opa v0.29.4 h1:rNa/Gd3Fs0xWgL0aZoyblRwCZLJsSLDQOhnck6DWpaA=
+github.com/open-policy-agent/opa v0.29.4/go.mod h1:ZCOTD3yyFR8JvF8ETdWdiSPn9WcF1dXeQWOv7VoPorU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -50,7 +50,7 @@ spec:
             - "--config-path"
             - "/config/envoy.yaml"
         - name: opa-envoy
-          image: openpolicyagent/opa:0.29.1-envoy
+          image: openpolicyagent/opa:0.29.4-envoy
           securityContext:
             runAsUser: 1111
           volumeMounts:

--- a/vendor/github.com/open-policy-agent/opa/bundle/filefs.go
+++ b/vendor/github.com/open-policy-agent/opa/bundle/filefs.go
@@ -1,0 +1,73 @@
+// +build go1.16
+
+package bundle
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"sync"
+)
+
+const (
+	defaultFSLoaderRoot = "."
+)
+
+type dirLoaderFS struct {
+	sync.Mutex
+	filesystem fs.FS
+	files      []string
+	idx        int
+}
+
+// NewFSLoader returns a basic DirectoryLoader implementation
+// that will load files from a fs.FS interface
+func NewFSLoader(filesystem fs.FS) (DirectoryLoader, error) {
+	d := dirLoaderFS{
+		filesystem: filesystem,
+	}
+
+	err := fs.WalkDir(d.filesystem, defaultFSLoaderRoot, d.walkDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	return &d, nil
+}
+
+func (d *dirLoaderFS) walkDir(path string, dirEntry fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if dirEntry != nil && dirEntry.Type().IsRegular() {
+		d.files = append(d.files, path)
+	}
+
+	return nil
+}
+
+// NextFile iterates to the next file in the directory tree
+// and returns a file Descriptor for the file.
+func (d *dirLoaderFS) NextFile() (*Descriptor, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	// If done reading files then just return io.EOF
+	// errors for each NextFile() call
+	if d.idx >= len(d.files) {
+		return nil, io.EOF
+	}
+
+	fileName := d.files[d.idx]
+	d.idx++
+
+	fh, err := d.filesystem.Open(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", fileName, err)
+	}
+
+	fileNameWithSlash := fmt.Sprintf("/%s", fileName)
+	f := newDescriptor(fileNameWithSlash, fileNameWithSlash, fh).withCloser(fh)
+	return f, nil
+}

--- a/vendor/github.com/open-policy-agent/opa/internal/rego/opa/nop.go
+++ b/vendor/github.com/open-policy-agent/opa/internal/rego/opa/nop.go
@@ -20,8 +20,9 @@ type OPA struct {
 func New() *OPA {
 	fmt.Fprintf(os.Stderr, `WebAssembly runtime not supported in this build.
 ----------------------------------------------------------------------------------
-Please download OPA from https://www.openpolicyagent.org/docs/latest/#running-opa,
-or build it yourself with Wasm enabled.
+Please download an OPA binay with Wasm enabled from
+  https://www.openpolicyagent.org/docs/latest/#running-opa
+or build it yourself (with Wasm enabled).
 ----------------------------------------------------------------------------------
 `)
 	os.Exit(1)

--- a/vendor/github.com/open-policy-agent/opa/topdown/eval.go
+++ b/vendor/github.com/open-policy-agent/opa/topdown/eval.go
@@ -1506,11 +1506,13 @@ func (e evalFunc) eval(iter unifyIterator) error {
 		return err
 	}
 
-	argCount := len(ir.Rules[0].Head.Args)
-
-	if ir.Empty() {
+	// default functions aren't supported:
+	// https://github.com/open-policy-agent/opa/issues/2445
+	if len(ir.Rules) == 0 {
 		return nil
 	}
+
+	argCount := len(ir.Rules[0].Head.Args)
 
 	if len(ir.Else) > 0 && e.e.unknown(e.e.query[e.e.index], e.e.bindings) {
 		// Partial evaluation of ordered rules is not supported currently. Save the

--- a/vendor/github.com/open-policy-agent/opa/version/version.go
+++ b/vendor/github.com/open-policy-agent/opa/version/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is the canonical version of OPA.
-var Version = "0.29.1"
+var Version = "0.29.4"
 
 // GoVersion is the version of Go this was built with
 var GoVersion = runtime.Version()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/mattn/go-runewidth
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/olekukonko/tablewriter v0.0.5
 github.com/olekukonko/tablewriter
-# github.com/open-policy-agent/opa v0.29.1
+# github.com/open-policy-agent/opa v0.29.4
 ## explicit
 github.com/open-policy-agent/opa/ast
 github.com/open-policy-agent/opa/ast/internal/scanner


### PR DESCRIPTION
Something seemed to have gone wrong in the auto-updater. Trying to do
this manually.
