### PR TITLE
Fix unmarshal json when Content-Type is application/json

### DIFF
--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -126,7 +126,7 @@ func getParsedBody(logEntry *logrus.Entry, headers map[string]string, body strin
 				}
 			}
 
-			err := util.Unmarshal([]byte(body), &data)
+			err := util.UnmarshalJSON([]byte(body), &data)
 			if err != nil {
 				return nil, false, err
 			}

--- a/envoyauth/request_test.go
+++ b/envoyauth/request_test.go
@@ -73,7 +73,7 @@ func TestGetParsedBody(t *testing.T) {
 			  "headers": {
 				"content-type": "application/json"
 			  },
-			  "body": "foo"
+			  "body": "\"foo\""
 			}
 		  }
 		}
@@ -171,12 +171,26 @@ func TestGetParsedBody(t *testing.T) {
 		}
 	  }`
 
+	requestBodyWithJSONSpecialChars := `{
+		"attributes": {
+		  "request": {
+			"http": {
+			  "headers": {
+				"content-type": "application/json"
+			  },
+			  "body": "[\"\\\"\", \"\\\\\", \"\\/\", \"/\", \"\\b\", \"\\f\", \"\\n\", \"\\r\", \"\\t\", \"\\u0041\"]"
+			}
+		  }
+		}
+	  }`
+
 	expectedNumber := json.Number("42")
 	expectedObject := map[string]interface{}{
 		"firstname": "foo",
 		"lastname":  "bar",
 	}
 	expectedArray := []interface{}{"hello", "opa"}
+	expectedJSONSpecialChars := []interface{}{`"`, `\`, "/", "/", "\b", "\f", "\n", "\r", "\t", "A"}
 
 	tests := map[string]struct {
 		input           *ext_authz.CheckRequest
@@ -184,16 +198,17 @@ func TestGetParsedBody(t *testing.T) {
 		isBodyTruncated bool
 		err             error
 	}{
-		"no_content_type":           {input: createCheckRequest(requestNoContentType), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_text":         {input: createCheckRequest(requestContentTypeText), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_json_string":  {input: createCheckRequest(requestContentTypeJSONString), want: "foo", isBodyTruncated: false, err: nil},
-		"content_type_json_boolean": {input: createCheckRequest(requestContentTypeJSONBoolean), want: true, isBodyTruncated: false, err: nil},
-		"content_type_json_number":  {input: createCheckRequest(requestContentTypeJSONNumber), want: expectedNumber, isBodyTruncated: false, err: nil},
-		"content_type_json_null":    {input: createCheckRequest(requestContentTypeJSONNull), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_json_object":  {input: createCheckRequest(requestContentTypeJSONObject), want: expectedObject, isBodyTruncated: false, err: nil},
-		"content_type_json_array":   {input: createCheckRequest(requestContentTypeJSONArray), want: expectedArray, isBodyTruncated: false, err: nil},
-		"empty_content":             {input: createCheckRequest(requestEmptyContent), want: nil, isBodyTruncated: false, err: nil},
-		"body_truncated":            {input: createCheckRequest(requestBodyTruncated), want: nil, isBodyTruncated: true, err: nil},
+		"no_content_type":                      {input: createCheckRequest(requestNoContentType), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_text":                    {input: createCheckRequest(requestContentTypeText), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_json_string":             {input: createCheckRequest(requestContentTypeJSONString), want: "foo", isBodyTruncated: false, err: nil},
+		"content_type_json_boolean":            {input: createCheckRequest(requestContentTypeJSONBoolean), want: true, isBodyTruncated: false, err: nil},
+		"content_type_json_number":             {input: createCheckRequest(requestContentTypeJSONNumber), want: expectedNumber, isBodyTruncated: false, err: nil},
+		"content_type_json_null":               {input: createCheckRequest(requestContentTypeJSONNull), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_json_object":             {input: createCheckRequest(requestContentTypeJSONObject), want: expectedObject, isBodyTruncated: false, err: nil},
+		"content_type_json_array":              {input: createCheckRequest(requestContentTypeJSONArray), want: expectedArray, isBodyTruncated: false, err: nil},
+		"content_type_json_with_special_chars": {input: createCheckRequest(requestBodyWithJSONSpecialChars), want: expectedJSONSpecialChars, isBodyTruncated: false, err: nil},
+		"empty_content":                        {input: createCheckRequest(requestEmptyContent), want: nil, isBodyTruncated: false, err: nil},
+		"body_truncated":                       {input: createCheckRequest(requestBodyTruncated), want: nil, isBodyTruncated: true, err: nil},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
It should not be able to parse yaml when Content-Type is application/json.
However `util.Unmarshal` is a utility that can parse yaml or json,
so if you put yaml in the body when Content-Type is application/json, it will be parsed.
Therefore, change the calling function to a `util.UnmarshalJSON`, and make it possible to parse only json.

In addition, `util.Unmarshal` was not possible to unmarshal a json string containing `\/` (which is an escaped `/`).
Json is supposed to consider slashes (`/`) as escapable characters (not required).
It could not parse a json body containing string of `\/`.
Because of the above, the opa-envoy-plugin eventually returned 403 whenever the Content-Type was application/json and the json contained `\/` in the string.
You can also avoid this problem by using the `util.UnmarshalJSON`.

Reference information
https://github.com/open-policy-agent/opa/pull/3571