### PR TITLE
build: update tag script

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -1,0 +1,41 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate:
+    name: Update versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Commit & Push
+        shell: bash
+        run: |
+          # Commit any changes and push as needed.
+
+          # See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+          AUTHOR=version-tag-updater
+          git config user.name ${AUTHOR}
+          git config user.email ${AUTHOR}@github.com
+
+          # Prevent looping if the build was non-deterministic..
+          CAN_PUSH=1
+          if [[ "$(git log -1 --pretty=format:'%an')" == "${AUTHOR}" ]]; then
+              CAN_PUSH=0
+          fi
+
+          if ./build/update-opa-version.sh; then
+            if [[ "${CAN_PUSH}" == "1" ]]; then
+              git push
+            else
+              echo "Previous commit was auto-generated -- Aborting!"
+              exit 1
+            fi
+          else
+            echo "No generated changes to push!"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
 
 .PHONY: all build build-darwin build-linux build-windows clean check check-fmt check-vet check-lint \
     deploy-ci docker-login generate image image-quick push push-latest tag-latest \
-    test test-cluster test-e2e update-opa update-istio-quickstart-version version
+    test test-cluster test-e2e update-istio-quickstart-version version
 
 ######################################################
 #
@@ -105,9 +105,6 @@ docker-login:
 	@echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USER} --password-stdin
 
 deploy-ci: docker-login image push tag-latest push-latest
-
-update-opa:
-	@./build/update-opa-version.sh $(TAG)
 
 update-istio-quickstart-version:
 	sed -i "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:latest-istio\"\,/;}" examples/istio/quick_start.yaml

--- a/build/update-opa-version.sh
+++ b/build/update-opa-version.sh
@@ -1,43 +1,36 @@
 #!/usr/bin/env bash
-# Script to revendor OPA, Add and Commit changes if needed
+# Script to update version references following an OPA version bump
 
 set +e
 set -x
 
-usage() {
-    echo "update-opa-version.sh <VERSION> eg. update-opa-version.sh v0.8.0"
-}
+FILES=(README.md quick_start.yaml examples/istio/quick_start.yaml)
 
-# Check if OPA version provided
-if [ $# -eq 0 ]
-  then
-    echo "OPA version not provided"
-    usage
-    exit 1
+# e.g. 0.29.4 (no 'v' prefix)
+tag=$(go list -m -f '{{ .Version }}' github.com/open-policy-agent/opa | cut -c 2-)
+
+# update plugin image version in README
+sed -i.bak "s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-envoy/" README.md && rm README.md.bak
+
+# update plugin image version in quick_start.yaml for Envoy
+sed -i.bak "s/image: openpolicyagent\/opa:.*/image: openpolicyagent\/opa:$tag-envoy/" quick_start.yaml && rm quick_start.yaml.bak
+
+# update plugin image version in quick_start.yaml for the Istio deployment example
+sed -i.bak "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio\"\,/;}" examples/istio/quick_start.yaml && rm examples/istio/quick_start.yaml.bak
+sed -i.bak "s/image: openpolicyagent\/opa:.*/image: openpolicyagent\/opa:$tag/" examples/istio/quick_start.yaml && rm examples/istio/quick_start.yaml.bak
+
+for file in "${FILES[@]}"; do
+  git add "$file"
+done
+
+if [[ -z "$(git diff --name-only --cached)" ]]; then
+  echo "No version changes to commit!"
+  exit 1
 fi
 
-# Update OPA version
-env GO111MODULE=on go get github.com/open-policy-agent/opa@$1
+git commit -m "examples: update OPA version tags ($tag)"
 
-# Check if OPA version has changed
-git status |  grep  go.mod
-if [ $? -eq 0 ]; then
-
-  tag=$(echo $1 | cut -c 2-)   # Remove 'v' in Tag. Eg. v0.8.0 -> 0.8.0
-
-  # update plugin image version in README
-  sed -i.bak "s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-envoy/" README.md && rm README.md.bak
-
-  # update plugin image version in quick_start.yaml for Envoy
-  sed -i.bak "s/image: openpolicyagent\/opa:.*/image: openpolicyagent\/opa:$tag-envoy/" quick_start.yaml && rm quick_start.yaml.bak
-
-  # update plugin image version in quick_start.yaml for the Istio deployment example
-  sed -i.bak "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio\"\,/;}" examples/istio/quick_start.yaml && rm examples/istio/quick_start.yaml.bak
-  sed -i.bak "s/image: openpolicyagent\/opa:.*/image: openpolicyagent\/opa:$tag/" examples/istio/quick_start.yaml && rm examples/istio/quick_start.yaml.bak
-
-  # update vendor
-  env GO111MODULE=on go mod vendor
-
-  # add changes
-  git add .
-fi 
+echo
+echo "Committed changes for files:"
+git diff-tree --no-commit-id --name-only -r HEAD
+echo


### PR DESCRIPTION
This allows us to use dependabot for updating OPA.

For any merge, we'll check if the version of OPA has changed,
and if so, push a commit fixing the version tags in the example
yamls.

It's done in a rather blunt manner: we replace whatever version
is in the yamls with whatever version we have for opa in go.mod,
and if the result is different from what we had before, we'll
push it to main.