### PR TITLE
Add support for listening on a UNIX Domain Socket

### DIFF
--- a/examples/envoy-uds/README.md
+++ b/examples/envoy-uds/README.md
@@ -1,0 +1,68 @@
+# Envoy External Authz and UNIX Domain Socket (UDS) example
+
+This tutorial shows how Envoy’s External authorization filter can be used with OPA as an authorization service. The
+OPA-Envoy plugin is configured to listen on a UNIX Domain Socket.
+
+## Steps
+
+### 1. Start Minikube
+
+```bash
+minikube start
+```
+
+### 2. Install OPA-Envoy.
+
+```bash
+kubectl apply -f quick_start.yaml
+```
+
+The `quick_start.yaml` manifest defines the following resources:
+
+ * A ConfigMap containing an Envoy configuration with an External Authorization Filter to direct authorization
+checks to the OPA-Envoy sidecar. It uses the Google C++ gRPC client to specify the UDS for the OPA-Envoy container.
+See `kubectl get configmap proxy-config` for details.
+
+* OPA configuration file, and an OPA policy into ConfigMaps in the namespace where the app will be deployed, e.g., `default`.
+
+* A Deployment consisting an example Go application with OPA-Envoy and Envoy sidecars.
+
+* An `emptyDir` volume called `opa-socket` that the OPA-Envoy and Envoy containers share.
+
+### 3. Make the application accessible outside the cluster.
+
+```bash
+kubectl expose deployment example-app --type=NodePort --name=example-app-service --port=8080
+```
+
+### 4. Set the `SERVICE_URL` environment variable to the service’s IP/port.
+
+**minikube**:
+
+```bash
+export SERVICE_PORT=$(kubectl get service example-app-service -o jsonpath='{.spec.ports[?(@.port==8080)].nodePort}')
+export SERVICE_HOST=$(minikube ip)
+export SERVICE_URL=$SERVICE_HOST:$SERVICE_PORT
+echo $SERVICE_URL
+```
+
+**minikube (example)**:
+
+```bash
+192.168.99.100:31380
+```
+
+### 5. Exercise the sample OPA policy.
+
+For convenience, we’ll want to store Alice’s token in environment variables.
+
+```bash
+export ALICE_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiZ3Vlc3QiLCJzdWIiOiJZV3hwWTJVPSIsIm5iZiI6MTUxNDg1MTEzOSwiZXhwIjoxNjQxMDgxNTM5fQ.K5DnnbbIOspRbpCr2IKXE9cPVatGOCBrBQobQmBmaeU"
+```
+
+Check that `Alice` can get employees **but cannot** create one.
+
+```bash
+curl -i -H "Authorization: Bearer "$ALICE_TOKEN"" http://$SERVICE_URL/people
+curl -i -H "Authorization: Bearer "$ALICE_TOKEN"" -d '{"firstname":"Charlie", "lastname":"OPA"}' -H "Content-Type: application/json" -X POST http://$SERVICE_URL/people
+```

--- a/examples/envoy-uds/quick_start.yaml
+++ b/examples/envoy-uds/quick_start.yaml
@@ -1,0 +1,243 @@
+####################################################
+# App Deployment with OPA-Envoy and Envoy sidecars.
+####################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  labels:
+    app: example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      initContainers:
+        - name: proxy-init
+          image: openpolicyagent/proxy_init:v5
+          # Configure the iptables bootstrap script to redirect traffic to the
+          # Envoy proxy on port 8000, specify that Envoy will be running as user
+          # 1111, and that we want to exclude port 8282 from the proxy for the
+          # OPA health checks. These values must match up with the configuration
+          # defined below for the "envoy" and "opa" containers.
+          args: ["-p", "8000", "-u", "1111", "-w", "8282"]
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            runAsNonRoot: false
+            runAsUser: 0
+      containers:
+        - name: app
+          image: openpolicyagent/demo-test-server:v1
+          ports:
+            - containerPort: 8080
+        - name: envoy
+          image: envoyproxy/envoy:v1.17.0
+          env:
+            - name: ENVOY_UID
+              value: "1111"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /config
+              name: proxy-config
+            - readOnly: false
+              mountPath: /run/opa/sockets
+              name: opa-socket
+          args:
+            - "envoy"
+            - "--log-level"
+            - "debug"
+            - "--config-path"
+            - "/config/envoy.yaml"
+        - name: opa-envoy
+          image: openpolicyagent/opa:latest-envoy
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+            - readOnly: true
+              mountPath: /policy
+              name: opa-policy
+            - readOnly: true
+              mountPath: /config
+              name: opa-envoy-config
+            - readOnly: false
+              mountPath: /run/opa/sockets
+              name: opa-socket
+          args:
+            - "run"
+            - "--server"
+            - "--config-file=/config/config.yaml"
+            - "--addr=localhost:8181"
+            - "--diagnostic-addr=0.0.0.0:8282"
+            - "--ignore=.*"
+            - "/policy/policy.rego"
+          livenessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTP
+              port: 8282
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTP
+              port: 8282
+            initialDelaySeconds: 5
+            periodSeconds: 15
+      volumes:
+        - name: proxy-config
+          configMap:
+            name: proxy-config
+        - name: opa-policy
+          configMap:
+            name: opa-policy
+        - name: opa-envoy-config
+          configMap:
+            name: opa-envoy-config
+        - name: opa-socket
+          emptyDir: {}
+---
+############################################################
+# Example configuration to bootstrap OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-envoy-config
+data:
+  config.yaml: |
+    plugins:
+      envoy_ext_authz_grpc:
+        addr: unix:///run/opa/sockets/auth.sock
+        path: envoy/authz/allow
+        enable-reflection: true
+    decision_logs:
+      console: true
+---
+######################################################################
+# Envoy Config with External Authorization filter that will query OPA.
+######################################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+      - address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8000
+        filter_chains:
+        - filters:
+          - name: envoy.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              codec_type: auto
+              stat_prefix: ingress_http
+              route_config:
+                name: local_route
+                virtual_hosts:
+                - name: backend
+                  domains:
+                  - "*"
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: service
+              http_filters:
+              - name: envoy.ext_authz
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                  transport_api_version: V3
+                  with_request_body:
+                    max_request_bytes: 8192
+                    allow_partial_message: true
+                    pack_as_bytes: true
+                  failure_mode_allow: false
+                  grpc_service:
+                    google_grpc:
+                      stat_prefix: ext_authz
+                      target_uri: unix:///run/opa/sockets/auth.sock
+                    timeout: 0.5s
+              - name: envoy.filters.http.router
+      clusters:
+      - name: service
+        connect_timeout: 0.25s
+        type: strict_dns
+        lb_policy: round_robin
+        load_assignment:
+          cluster_name: service
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8080
+    admin:
+      access_log_path: "/dev/null"
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8001
+---
+############################################################
+# Example policy to enforce into OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-policy
+data:
+  policy.rego: |
+    package envoy.authz
+
+    import input.attributes.request.http as http_request
+
+    default allow = false
+
+    token = {"valid": valid, "payload": payload} {
+        [_, encoded] := split(http_request.headers.authorization, " ")
+        [valid, _, payload] := io.jwt.decode_verify(encoded, {"secret": "secret"})
+    }
+
+    allow {
+        is_token_valid
+        action_allowed
+    }
+
+    is_token_valid {
+      token.valid
+      now := time.now_ns() / 1000000000
+      token.payload.nbf <= now
+      now < token.payload.exp
+    }
+
+    action_allowed {
+      http_request.method == "GET"
+      token.payload.role == "guest"
+      glob.match("/people*", [], http_request.path)
+    }
+
+    action_allowed {
+      http_request.method == "GET"
+      token.payload.role == "admin"
+      glob.match("/people*", [], http_request.path)
+    }
+
+    action_allowed {
+      http_request.method == "POST"
+      token.payload.role == "admin"
+      glob.match("/people", [], http_request.path)
+      lower(input.parsed_body.firstname) != base64url.decode(token.payload.sub)
+    }


### PR DESCRIPTION
This commit enables the OPA-Envoy server to listen on
a UNIX Domain Socket through the existing `addr` field
of the plugin config.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>