### PR TITLE
build: Update commit author in plugin rev script

### DIFF
--- a/build/get-plugin-rev.sh
+++ b/build/get-plugin-rev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Script to get number of commits from the last OPA revendoring
 
-GIT_SHA=$(git log -n 1 --oneline  --pretty=format:"%h" --author=opa-updater-automation)
+GIT_SHA=$(git log -n 1 --oneline  --pretty=format:"%h" --author=version-tag-updater)
 COMMITS=$(git rev-list $GIT_SHA..HEAD --count)
 
 if [ $COMMITS -ne 0 ]; then


### PR DESCRIPTION
Earlier opa-updater-automation was the author for
updating the OPA version in the example yamls and README.
After we changed to use dependabot for updating OPA, the examples
are now updated by the version-tag-updater author.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>