### PR TITLE
Update docker image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To deploy OPA-Envoy include the following container in your Kubernetes Deploymen
 
 ```yaml
 containers:
-- image: openpolicyagent/opa:0.29.4-envoy
+- image: openpolicyagent/opa:0.29.4-envoy-2
   imagePullPolicy: IfNotPresent
   name: opa-envoy
   volumeMounts:

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -50,7 +50,7 @@ spec:
             - "--config-path"
             - "/config/envoy.yaml"
         - name: opa-envoy
-          image: openpolicyagent/opa:0.29.4-envoy
+          image: openpolicyagent/opa:0.29.4-envoy-2
           securityContext:
             runAsUser: 1111
           volumeMounts:


### PR DESCRIPTION
When I tried to do a quick start, I couldn't pull the docker image.
It didn't seem to be pushed [here](https://hub.docker.com/r/openpolicyagent/opa/tags?page=1&ordering=last_updated&name=0.29.4-envoy), but isn't this version? : `0.29.4-envoy-2`
