### PR TITLE
workflow: only fix opa tag following dependabot merge

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -16,7 +16,11 @@ jobs:
       - name: Commit & Push
         shell: bash
         run: |
-          # Commit any changes and push as needed.
+          # Only run this following a merge of dependabot's PR
+          if [[ "$(git log -1 --pretty=format:'%an')" != "dependabot[bot]" ]]; then
+            echo "Previous commit was not from dependabot, aborting."
+            exit 0
+          fi
 
           # See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
           AUTHOR=version-tag-updater


### PR DESCRIPTION
The update script only did the right thing following the merge of a dependabot PR, but made a mess when anything else was merged.

https://github.com/srenatus/opa-istio-plugin/runs/2942210939?check_suite_focus=true 👈 Hope this does the trick.