### PR TITLE
build: Update commit author in plugin rev script

### DIFF
--- a/build/get-plugin-rev.sh
+++ b/build/get-plugin-rev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Script to get number of commits from the last OPA revendoring
 
-GIT_SHA=$(git log -n 1 --oneline  --pretty=format:"%h" --author=version-tag-updater)
+GIT_SHA=$(git log -n 1 --oneline  --pretty=format:"%h" --author=dependabot)
 COMMITS=$(git rev-list $GIT_SHA..HEAD --count)
 
 if [ $COMMITS -ne 0 ]; then


### PR DESCRIPTION
Earlier version-tag-updater was responsible to update
the OPA version in the example yamls and README.
We now use the latest image in these files and hence
the version-tag-updater author no longer exists.
This change updates the author to dependabot which is
now in charge of bumping the OPA version.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>