### PR TITLE
remove unused make target, bump istio+kind versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -79,9 +79,6 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y bats
 
-          # Prepare quick_start.yaml
-          make update-istio-quickstart-version
-
           # Make docker image available to k8s
           kind load docker-image openpolicyagent/opa:latest-istio
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
 
 .PHONY: all build build-darwin build-linux build-windows clean check check-fmt check-vet check-lint \
     deploy-ci docker-login generate image image-quick push push-latest tag-latest \
-    test test-cluster test-e2e update-istio-quickstart-version version
+    test test-cluster test-e2e version
 
 ######################################################
 #
@@ -105,9 +105,6 @@ docker-login:
 	@echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USER} --password-stdin
 
 deploy-ci: docker-login image push tag-latest push-latest
-
-update-istio-quickstart-version:
-	sed -i "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:latest-istio\"\,/;}" examples/istio/quick_start.yaml
 
 test: generate
 	$(DISABLE_CGO) $(GO) test -v -bench=. $(PACKAGES)

--- a/build/install-istio-with-kind.sh
+++ b/build/install-istio-with-kind.sh
@@ -6,8 +6,8 @@ set -x
 
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
-KIND_VERSION=0.9.0
-ISTIO_VERSION=1.8.2
+KIND_VERSION=0.11.1
+ISTIO_VERSION=1.8.6
 
 # Download and install kind
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${GOOS}-${GOARCH} --output kind && chmod +x kind && sudo mv kind /usr/local/bin/


### PR DESCRIPTION
I've not been able to get a grip on what happens with the istio e2e tests in #273 (and #270), but it looks like bumping dependencies helps? So let's do that. 🐑 