### PR TITLE
workflow: let dependabot handle all go mod dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,5 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
-    allow:
-      - dependency-name: github.com/open-policy-agent/opa
     schedule:
       interval: daily


### PR DESCRIPTION
Previously, we've only used it for OPA.

~🚧 We'll have to update our script logic if a dependabot-authored commit no longer signifies that OPA was updated.~ #300 resolved that.