### PR TITLE
Use CUSTOM AuthorizationPolicies in Istio example

### DIFF
--- a/build/install-istio-with-kind.sh
+++ b/build/install-istio-with-kind.sh
@@ -7,7 +7,7 @@ set -x
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
 KIND_VERSION=0.11.1
-ISTIO_VERSION=1.8.6
+ISTIO_VERSION=1.9.7
 
 # Download and install kind
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${GOOS}-${GOARCH} --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
@@ -27,6 +27,7 @@ kubectl cluster-info --context kind-kind
 # Download and install Istio
 curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh - && mv istio-${ISTIO_VERSION} /tmp
 pushd /tmp/istio-${ISTIO_VERSION}
-bin/istioctl install -y --set profile=demo
+kubectl create namespace istio-system  # Not needed with Istio v1.10+, created by operator automatically
+bin/istioctl operator init
 popd
-kubectl -n istio-system wait --for=condition=available --timeout=600s --all deployment
+kubectl -n istio-operator wait --for=condition=available --timeout=600s --all deployment

--- a/examples/istio/authz.yaml
+++ b/examples/istio/authz.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: opa-istio
+spec:
+  action: CUSTOM
+  provider:
+    name: "opa-istio"
+  rules:
+    # An empty rule applies to all requests
+    - {}

--- a/examples/istio/istiooperator.yaml
+++ b/examples/istio/istiooperator.yaml
@@ -1,0 +1,15 @@
+############################################################
+# IstioOperator configuration with CUSTOM AuthZ provider that will query OPA.
+############################################################
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: istiocontrolplane
+spec:
+  meshConfig:
+    extensionProviders:
+      - name: "opa-istio"
+        envoyExtAuthzGrpc:
+          service: "external-authz-grpc.local"
+          port: "9191"

--- a/examples/istio/quick_start.yaml
+++ b/examples/istio/quick_start.yaml
@@ -1,51 +1,29 @@
 ############################################################
-# Envoy External Authorization filter that will query OPA.
-############################################################
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: ext-authz
-  namespace: istio-system
-spec:
-  configPatches:
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_INBOUND
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-              subFilter:
-                name: "envoy.router"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: envoy.ext_authz
-          typed_config:
-            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-            transport_api_version: V3
-            status_on_error:
-              code: ServiceUnavailable
-            with_request_body:
-              max_request_bytes: 8192
-              allow_partial_message: true
-            grpc_service:
-              # NOTE(tsandall): when this was tested with the envoy_grpc client the gRPC
-              # server was receiving check requests over HTTP 1.1. The gRPC server in
-              # OPA-Istio would immediately close the connection and log that a bogus
-              # preamble was sent by the client (it expected HTTP 2). Switching to the
-              # google_grpc client resolved this issue.
-              google_grpc:
-                target_uri: 127.0.0.1:9191
-                stat_prefix: "ext_authz"
----
-############################################################
 # Namespace for cluster-wide OPA-Istio components.
 ############################################################
 apiVersion: v1
 kind: Namespace
 metadata:
   name: opa-istio
+---
+############################################################
+# Localhost ServiceEntry used by the extension provider in the mesh config
+############################################################
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-authz-grpc-local
+  namespace: opa-istio
+spec:
+  hosts:
+    - "external-authz-grpc.local" # The service name to be used in the extension provider in the mesh config.
+  endpoints:
+    - address: "127.0.0.1"
+  ports:
+    - name: grpc
+      number: 9191 # The port number to be used in the extension provider in the mesh config.
+      protocol: GRPC
+  resolution: STATIC
 ---
 ############################################################
 # TLS certificate for OPA admission controller.

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -6,6 +6,15 @@ BATS_TESTS_DIR=test/bats/tests
 WAIT_TIME=60
 SLEEP_TIME=1
 
+@test "deploy Istio control plane with operator" {
+  run kubectl apply -f examples/istio/istiooperator.yaml
+  assert_success
+
+  cmd='[[ $(kubectl get -n istio-system istiooperator istiocontrolplane -o "jsonpath={.status.status}") == "HEALTHY" ]]'
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+  assert_success
+}
+
 @test "install OPA-Envoy" {
   run kubectl apply -f examples/istio/quick_start.yaml
   assert_success
@@ -16,6 +25,11 @@ SLEEP_TIME=1
   assert_success
 
   run kubectl label namespace default istio-injection="enabled"
+  assert_success
+}
+
+@test "add AuthorizationPolicy to default namespace for external authorization" {
+  run kubectl apply -n default -f examples/istio/authz.yaml
   assert_success
 }
 


### PR DESCRIPTION
I tested Istio 1.9+'s new CUSTOM AuthorizationPolicy feature using injected OPA sidecars like the this project's Istio example and got it to work. This replaces the EnvoyFilter with a "provider" configuration entry in the mesh config which is referenced by the AuthorizationPolicy. To easily allow configuring the mesh config, I switched the Istio installation method to use the operator.

I think this is the new recommended way to do external authorization with Istio, so I'm submitting this PR if you'd like to update the Istio example.

See Istio documentation for more information:
https://istio.io/latest/docs/tasks/security/authorization/authz-custom/
https://istio.io/latest/blog/2021/better-external-authz/

* * * 

Minimum Istio version increased to 1.9. Installation instructions use Istio operator to allow configuring an envoyExtAuthzGrpc extension provider in the mesh config.

Localhost ServiceEntry added to allow provider to target a sidecar (127.0.0.1 IP address) instead of a Service.

A CUSTOM AuthorizationPolicy matches workloads and applies policy using the external authorization provider.

EnvoyFilter is removed.
