### PR TITLE
fix deadlock bundle decision plugins

### DIFF
--- a/envoyauth/evaluation.go
+++ b/envoyauth/evaluation.go
@@ -37,6 +37,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 		}
 
 		result.TxnID = txn.ID()
+		result.Txn = txn
 
 		logrus.WithFields(logrus.Fields{
 			"input": input,

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -9,6 +9,7 @@ import (
 	ext_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/open-policy-agent/opa-envoy-plugin/internal/util"
 	"github.com/open-policy-agent/opa/metrics"
+	"github.com/open-policy-agent/opa/storage"
 )
 
 // EvalResult - Captures the result from evaluating a query against an input
@@ -17,6 +18,7 @@ type EvalResult struct {
 	Revisions  map[string]string
 	DecisionID string
 	TxnID      uint64
+	Txn        storage.Transaction
 	Decision   interface{}
 	Metrics    metrics.Metrics
 }

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -34,15 +34,14 @@ func NewEvalResult() (*EvalResult, StopFunc, error) {
 		Metrics: metrics.New(),
 	}
 	er.DecisionID, err = util.UUID4()
-
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, err
 	}
 
 	er.Metrics.Timer(metrics.ServerHandler).Start()
 
 	stop := func() {
-		er.Metrics.Timer(metrics.ServerHandler).Stop()
+		_ = er.Metrics.Timer(metrics.ServerHandler).Stop()
 	}
 
 	return &er, stop, nil

--- a/opa/decisionlog/decision_log.go
+++ b/opa/decisionlog/decision_log.go
@@ -27,6 +27,7 @@ func LogDecision(ctx context.Context, manager *plugins.Manager, info *server.Inf
 		return nil
 	}
 
+	info.Txn = result.Txn
 	info.Revision = result.Revision
 
 	bundles := map[string]server.BundleInfo{}


### PR DESCRIPTION
🚧 The txn is definitely not passed to the decision logger.

It now is, but I haven't verified the behaviour in any real way yet. It would be nice to reproduce the dead lock via a test, or the race detector.

Fixes https://github.com/open-policy-agent/opa/issues/3722.