### PR TITLE
Fix deadlock when bundle and decision logging enabled

### DIFF
--- a/envoyauth/evaluation_test.go
+++ b/envoyauth/evaluation_test.go
@@ -3,11 +3,19 @@ package envoyauth
 import (
 	"context"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/open-policy-agent/opa/plugins/logs"
+
+	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/plugins"
+	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
+	iCache "github.com/open-policy-agent/opa/topdown/cache"
 )
 
 func TestGetRevisionLegacy(t *testing.T) {
@@ -101,4 +109,168 @@ func TestGetRevisionMulti(t *testing.T) {
 		t.Fatalf("Unexpected revision %v", result.Revision)
 	}
 
+}
+
+func TestEval(t *testing.T) {
+	ctx := context.Background()
+	server, err := testAuthzServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsedBody := make(map[string]interface{})
+	parsedBody["firstname"] = "foo"
+	parsedBody["lastname"] = "bar"
+
+	input := make(map[string]interface{})
+	input["parsed_body"] = parsedBody
+
+	inputValue, err := ast.InterfaceToValue(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Eval(ctx, server, inputValue, &EvalResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// include transaction in the result object
+	er := &EvalResult{}
+	var txn storage.Transaction
+	var txnClose TransactionCloser
+
+	txn, txnClose, err = er.GetTxn(ctx, server.Store())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer txnClose(ctx, err)
+	er.Txn = txn
+
+	err = Eval(ctx, server, inputValue, er)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testAuthzServer() (*mockExtAuthzGrpcServer, error) {
+
+	module := `
+		package envoy.authz
+
+		default allow = false
+
+        allow {
+			input.parsed_body.firstname == "foo"
+			input.parsed_body.lastname == "bar"
+		}`
+
+	ctx := context.Background()
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+	store.UpsertPolicy(ctx, txn, "example.rego", []byte(module))
+	store.Commit(ctx, txn)
+
+	m, err := plugins.New([]byte{}, "test", store)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Register("test_plugin", &testPlugin{})
+	config, err := logs.ParseConfig([]byte(`{"plugin": "test_plugin"}`), nil, []string{"test_plugin"})
+	if err != nil {
+		return nil, err
+	}
+
+	plugin := logs.New(config, m)
+	m.Register(logs.Name, plugin)
+
+	if err := m.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	path := "envoy/authz/allow"
+	query := "data." + strings.Replace(path, "/", ".", -1)
+	parsedQuery, err := ast.ParseBody(query)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := Config{
+		Addr:        ":0",
+		Path:        path,
+		parsedQuery: parsedQuery,
+	}
+
+	return &mockExtAuthzGrpcServer{
+		cfg:                 cfg,
+		manager:             m,
+		preparedQueryDoOnce: new(sync.Once),
+		//	interQueryBuiltinCache: iCache.NewInterQueryCache(m.InterQueryBuiltinCacheConfig()),
+	}, nil
+}
+
+type Config struct {
+	Addr        string `json:"addr"`
+	Path        string `json:"path"`
+	parsedQuery ast.Body
+}
+
+type mockExtAuthzGrpcServer struct {
+	cfg                 Config
+	manager             *plugins.Manager
+	preparedQuery       *rego.PreparedEvalQuery
+	preparedQueryDoOnce *sync.Once
+}
+
+func (m *mockExtAuthzGrpcServer) ParsedQuery() ast.Body {
+	return m.cfg.parsedQuery
+}
+
+func (m *mockExtAuthzGrpcServer) Store() storage.Store {
+	return m.manager.Store
+}
+
+func (m *mockExtAuthzGrpcServer) Compiler() *ast.Compiler {
+	return m.manager.GetCompiler()
+}
+
+func (m *mockExtAuthzGrpcServer) Runtime() *ast.Term {
+	return m.manager.Info
+}
+
+func (m *mockExtAuthzGrpcServer) PreparedQueryDoOnce() *sync.Once {
+	return m.preparedQueryDoOnce
+}
+
+func (m *mockExtAuthzGrpcServer) InterQueryBuiltinCache() iCache.InterQueryCache {
+	return nil
+}
+
+func (m *mockExtAuthzGrpcServer) PreparedQuery() *rego.PreparedEvalQuery {
+	return m.preparedQuery
+}
+
+func (m *mockExtAuthzGrpcServer) SetPreparedQuery(pq *rego.PreparedEvalQuery) {
+	m.preparedQuery = pq
+}
+
+type testPlugin struct {
+	events []logs.EventV1
+}
+
+func (p *testPlugin) Start(context.Context) error {
+	return nil
+}
+
+func (p *testPlugin) Stop(context.Context) {
+}
+
+func (p *testPlugin) Reconfigure(context.Context, interface{}) {
+}
+
+func (p *testPlugin) Log(_ context.Context, event logs.EventV1) error {
+	p.events = append(p.events, event)
+	return nil
 }

--- a/opa/decisionlog/decision_log.go
+++ b/opa/decisionlog/decision_log.go
@@ -37,6 +37,7 @@ func LogDecision(ctx context.Context, manager *plugins.Manager, info *server.Inf
 
 	info.DecisionID = result.DecisionID
 	info.Metrics = result.Metrics
+	info.Txn = result.Txn
 
 	if err != nil {
 		switch err.(type) {


### PR DESCRIPTION
This commit attempts to fix the deadlock that happens
when bundle and decision logging are both enabled.

The opa-envoy plugin creates a new transaction during
query evaluation and closes it once eval is complete.
Then when it attempts to log the decision, the decision
log plugin grabs mask mutex and calls the PrepareForEval
function in the rego package which tries to open a new
read transaction on the store since the log plugin does
not provide one. This call gets blocked
if concurrently the bundle plugin has a write transaction
open on the store. This write invokes the decision log plugin's callback
and tries to grab the mask mutex. This call gets blocked because
the decision log plugin is already holding onto it for the mask query.

To avoid this, we keep the transaction open in the opa-envoy plugin
till we log the decision.

Fixes: open-policy-agent/opa#3722

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>