### PR TITLE
feat(envoyauth_request): add partial support for multipart/form-data

### DIFF
--- a/envoyauth/request_test.go
+++ b/envoyauth/request_test.go
@@ -144,6 +144,34 @@ func TestGetParsedBody(t *testing.T) {
 		}
 	  }`
 
+	requestContentTypeMultipartFormData := `{
+		"attributes": {
+		  "request": {
+			"http": {
+			  "headers": {
+				"content-type": "multipart/form-data; boundary=foo"
+			  },
+			  "body": "--foo\nContent-Disposition: form-data; name=\"foo\"\nContent-Type: text/plain\n\nbar\n--foo--
+				"
+			}
+		  }
+		}
+	  }`
+
+	requestContentTypeMultipartFormDataWithJSON := `{
+		"attributes": {
+		  "request": {
+			"http": {
+			  "headers": {
+				"content-type": "multipart/form-data; boundary=foo"
+			  },
+			  "body": "--foo\nContent-Disposition: form-data; name=\"foo\"\nContent-Type: text/plain\n\nbar\n--foo\nContent-Disposition: form-data; name=\"bar\"\nContent-Type: application/json;\n\n{\"name\": \"bar\"}\n--foo--
+				"
+			}
+		  }
+		}
+	  }`
+
 	requestEmptyContent := `{
 		"attributes": {
 		  "request": {
@@ -251,6 +279,15 @@ func TestGetParsedBody(t *testing.T) {
 	}
 	expectedArray := []interface{}{"hello", "opa"}
 	expectedJSONSpecialChars := []interface{}{`"`, `\`, "/", "/", "\b", "\f", "\n", "\r", "\t", "A"}
+	expectedMultipartFormData := map[string][]interface{}{
+		"foo": {"bar"},
+	}
+	expectedMultipartFormDataWithJSON := map[string][]interface{}{
+		"foo": {"bar"},
+		"bar": {
+			map[string]interface{}{"name": "bar"},
+		},
+	}
 
 	tests := map[string]struct {
 		input           *ext_authz.CheckRequest
@@ -258,21 +295,23 @@ func TestGetParsedBody(t *testing.T) {
 		isBodyTruncated bool
 		err             error
 	}{
-		"no_content_type":                          {input: createCheckRequest(requestNoContentType), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_text":                        {input: createCheckRequest(requestContentTypeText), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_json_string":                 {input: createCheckRequest(requestContentTypeJSONString), want: "foo", isBodyTruncated: false, err: nil},
-		"content_type_json_boolean":                {input: createCheckRequest(requestContentTypeJSONBoolean), want: true, isBodyTruncated: false, err: nil},
-		"content_type_json_number":                 {input: createCheckRequest(requestContentTypeJSONNumber), want: expectedNumber, isBodyTruncated: false, err: nil},
-		"content_type_json_null":                   {input: createCheckRequest(requestContentTypeJSONNull), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_json_object":                 {input: createCheckRequest(requestContentTypeJSONObject), want: expectedObject, isBodyTruncated: false, err: nil},
-		"content_type_json_array":                  {input: createCheckRequest(requestContentTypeJSONArray), want: expectedArray, isBodyTruncated: false, err: nil},
-		"content_type_json_with_special_chars":     {input: createCheckRequest(requestBodyWithJSONSpecialChars), want: expectedJSONSpecialChars, isBodyTruncated: false, err: nil},
-		"empty_content":                            {input: createCheckRequest(requestEmptyContent), want: nil, isBodyTruncated: false, err: nil},
-		"body_truncated":                           {input: createCheckRequest(requestBodyTruncated), want: nil, isBodyTruncated: true, err: nil},
-		"content_type_url_encoded":                 {input: createCheckRequest(requestContentTypeURLEncoded), want: expectedURLEncodedObject, isBodyTruncated: false, err: nil},
-		"content_type_url_encoded_empty":           {input: createCheckRequest(requestContentTypeURLEncodedEmpty), want: nil, isBodyTruncated: false, err: nil},
-		"content_type_url_encoded_multiple_values": {input: createCheckRequest(requestContentTypeURLEncodedMultipleKeys), want: expectedURLEncodedObjectMultipleValues, isBodyTruncated: false, err: nil},
-		"content_type_url_encoded_truncated":       {input: createCheckRequest(requestContentTypeURLEncodedTruncated), want: nil, isBodyTruncated: true, err: nil},
+		"no_content_type":                            {input: createCheckRequest(requestNoContentType), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_text":                          {input: createCheckRequest(requestContentTypeText), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_json_string":                   {input: createCheckRequest(requestContentTypeJSONString), want: "foo", isBodyTruncated: false, err: nil},
+		"content_type_json_boolean":                  {input: createCheckRequest(requestContentTypeJSONBoolean), want: true, isBodyTruncated: false, err: nil},
+		"content_type_json_number":                   {input: createCheckRequest(requestContentTypeJSONNumber), want: expectedNumber, isBodyTruncated: false, err: nil},
+		"content_type_json_null":                     {input: createCheckRequest(requestContentTypeJSONNull), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_json_object":                   {input: createCheckRequest(requestContentTypeJSONObject), want: expectedObject, isBodyTruncated: false, err: nil},
+		"content_type_json_array":                    {input: createCheckRequest(requestContentTypeJSONArray), want: expectedArray, isBodyTruncated: false, err: nil},
+		"content_type_json_with_special_chars":       {input: createCheckRequest(requestBodyWithJSONSpecialChars), want: expectedJSONSpecialChars, isBodyTruncated: false, err: nil},
+		"content_type_multipart_form_data":           {input: createCheckRequest(requestContentTypeMultipartFormData), want: expectedMultipartFormData, isBodyTruncated: false, err: nil},
+		"content_type_multipart_form_data_with_json": {input: createCheckRequest(requestContentTypeMultipartFormDataWithJSON), want: expectedMultipartFormDataWithJSON, isBodyTruncated: false, err: nil},
+		"empty_content":                              {input: createCheckRequest(requestEmptyContent), want: nil, isBodyTruncated: false, err: nil},
+		"body_truncated":                             {input: createCheckRequest(requestBodyTruncated), want: nil, isBodyTruncated: true, err: nil},
+		"content_type_url_encoded":                   {input: createCheckRequest(requestContentTypeURLEncoded), want: expectedURLEncodedObject, isBodyTruncated: false, err: nil},
+		"content_type_url_encoded_empty":             {input: createCheckRequest(requestContentTypeURLEncodedEmpty), want: nil, isBodyTruncated: false, err: nil},
+		"content_type_url_encoded_multiple_values":   {input: createCheckRequest(requestContentTypeURLEncodedMultipleKeys), want: expectedURLEncodedObjectMultipleValues, isBodyTruncated: false, err: nil},
+		"content_type_url_encoded_truncated":         {input: createCheckRequest(requestContentTypeURLEncodedTruncated), want: nil, isBodyTruncated: true, err: nil},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Hi,

At the moment, `opa-envoy-plugin` is not able to parse `multipart/form-data` payloads. I don't know whether this was made on purpose because of potential issues regarding the parsing of uploaded files or for any other reason so please let me know it all that sounds wrong to you folks.

As far as I am aware of, Envoy needs to have `pack_as_bytes` set to `true` to be able to process binary payloads such as files. That's why I'm evaluating both cases where `body` or `rawBody` could be empty, depending on the configuration of the `EnvoyFilter`.

Also, I've been thinking about only reading form parts that have an explicit `Content-Type` header set to `text/plain` and `application/json` to reduce parsing overhead and memory allocation. However, most of the times `text/plain` parts themselves are missing this header resulting in basically no fields being parsed at all.

Parsing returns a `map[string][]interface{}` as multiple parts can share the same `name` property.

Unit tests have been added and I've ran this image on top of an existing cluster to perform some basic testing in both cases where `body` or `rawBody` would be empty depending on the `ext_authz` filter configuration.

What do you folks think ?

Thanks in advance for taking the time to review my proposal.

