### PR TITLE
build: use vendored opa dir to determine plugin ref

### DIFF
--- a/build/get-plugin-rev.sh
+++ b/build/get-plugin-rev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Script to get number of commits from the last OPA revendoring
 
-GIT_SHA=$(git log -n 1 --oneline  --pretty=format:"%h" --author=dependabot)
+GIT_SHA=$(git log -n 1 --pretty=format:%H -- vendor/github.com/open-policy-agent/opa)
 COMMITS=$(git rev-list $GIT_SHA..HEAD --count)
 
 if [ $COMMITS -ne 0 ]; then


### PR DESCRIPTION
Because like with 0.35.0, it might not be dependabot that bumped the version. Also unblocks #274.