### PR TITLE
build/get-plugin-rev.sh: check commits for changes to opa in go.mod

### DIFF
--- a/build/get-plugin-rev.sh
+++ b/build/get-plugin-rev.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Script to get number of commits from the last OPA revendoring
 
-GIT_SHA=$(git log -n 1 --pretty=format:%H -- vendor/github.com/open-policy-agent/opa)
+LINE=$(git grep -n "github.com/open-policy-agent/opa " go.mod | awk -F: '{ print $2 }')
+GIT_SHA=$(git log -n 1 --pretty=format:%H -L $LINE,$LINE:go.mod | head -1)
 COMMITS=$(git rev-list $GIT_SHA..HEAD --count)
 
 if [ $COMMITS -ne 0 ]; then


### PR DESCRIPTION
We're now doing this:

1. determine the LINE that `github.com/open-policy-agent/opa` appears in
   in go.mod
2. check that line's history
3. capture the commit hash that has touched that line last, and
4. use that to determine the plugin revision
