### PR TITLE
feat(grpc): allow to configure grpc msg rcv/send sizes

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -940,6 +940,28 @@ func TestConfigValidWithPath(t *testing.T) {
 	}
 }
 
+func TestConfigValidWithGRPCMaxMessageSizes(t *testing.T) {
+
+	m, err := plugins.New([]byte{}, "test", inmem.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := `{"grpc-max-recv-msg-size": 1000, "grpc-max-send-msg-size": 1000}`
+	config, err := Validate(m, []byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.GRPCMaxRecvMsgSize != 1000 {
+		t.Fatalf("Expected GRPC max receive message size to be 1000 but got %v", config.GRPCMaxRecvMsgSize)
+	}
+
+	if config.GRPCMaxSendMsgSize != 1000 {
+		t.Fatalf("Expected GRPC max send message size to be 1000 but got %v", config.GRPCMaxSendMsgSize)
+	}
+}
+
 func TestConfigValidDefault(t *testing.T) {
 
 	m, err := plugins.New([]byte{}, "test", inmem.New())
@@ -975,6 +997,14 @@ func TestConfigValidDefault(t *testing.T) {
 
 	if config.EnableReflection {
 		t.Fatal("Expected enable-reflection config to be disabled by default")
+	}
+
+	if config.GRPCMaxRecvMsgSize != defaultGRPCServerMaxReceiveMessageSize {
+		t.Fatalf("Expected GRPC max receive message size %d but got %d", defaultGRPCServerMaxReceiveMessageSize, config.GRPCMaxRecvMsgSize)
+	}
+
+	if config.GRPCMaxSendMsgSize != defaultGRPCServerMaxSendMessageSize {
+		t.Fatalf("Expected GRPC max send message size %d but got %d", defaultGRPCServerMaxSendMessageSize, config.GRPCMaxSendMsgSize)
 	}
 }
 


### PR DESCRIPTION
Hi,

I know that this has already been opened quite a few times without never being released so I'll try. This change introduces both `grpc-max-rcv-message-size` and `grpc-max-send-message-size` with default values being set to the ones from the official `grpc-go` library. It helps when dealing with large payloads.

I've deployed it on my clusters and it seems to work as expected.

Thanks in advance for reading