### PR TITLE
Support to control headers for the upstream and client

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -352,9 +352,22 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 		}
 
 		if status == int32(code.Code_OK) {
+
+			headersToRemove, err := result.GetRequestHTTPHeadersToRemove()
+			if err != nil {
+				return nil, stop, errors.Wrap(err, "failed to get request headers to remove")
+			}
+
+			responseHeadersToAdd, err := result.GetResponseHTTPHeadersToAdd()
+			if err != nil {
+				return nil, stop, errors.Wrap(err, "failed to get response headers to send to client")
+			}
+
 			resp.HttpResponse = &ext_authz_v3.CheckResponse_OkResponse{
 				OkResponse: &ext_authz_v3.OkHttpResponse{
-					Headers: responseHeaders,
+					Headers:              responseHeaders,
+					HeadersToRemove:      headersToRemove,
+					ResponseHeadersToAdd: responseHeadersToAdd,
 				},
 			}
 		} else {


### PR DESCRIPTION
This commit updates the policy interface to allow
a policy author to define headers that should be
removed before a request is sent upstream and added
to the response sent to the client. Both these
are applicable to successful ext authz responses.

Fixes: open-policy-agent/opa/issues/4417

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>