### PR TITLE
fix recurring errors when the execute returns exceptions

### DIFF
--- a/cmd/opa-envoy-plugin/main.go
+++ b/cmd/opa-envoy-plugin/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/open-policy-agent/opa-envoy-plugin/plugin"
@@ -18,7 +17,6 @@ func main() {
 	runtime.RegisterPlugin(plugin.PluginName, plugin.Factory{})
 
 	if err := cmd.RootCommand.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
the same fix can be applied to the other projects that are using cobra as well

complement: https://github.com/open-policy-agent/opa/issues/5115

e.g:
```shell
./opa_envoy_linux_amd64 sihn
Error: unknown command "sihn" for "opa_envoy_linux_amd64"

Did you mean this?
        sign

Run 'opa_envoy_linux_amd64 --help' for usage.
unknown command "sihn" for "opa_envoy_linux_amd64"

Did you mean this?
        sign
```