### PR TITLE
dependabot: track actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
I've noticed deprecation warnings from a docker/buildx action -- I suppose there is some update need. Let's have the bot do it.
