### PR TITLE
Fix AdmissionReview apiVersion to use v1.

### DIFF
--- a/examples/istio/quick_start.yaml
+++ b/examples/istio/quick_start.yaml
@@ -162,11 +162,14 @@ data:
   inject.rego: |
     package istio
 
+    uid := input.request.uid
+
     inject = {
-      "apiVersion": "admission.k8s.io/v1beta1",
+      "apiVersion": "admission.k8s.io/v1",
       "kind": "AdmissionReview",
       "response": {
         "allowed": true,
+        "uid": uid,
         "patchType": "JSONPatch",
         "patch": base64.encode(json.marshal(patch)),
       },
@@ -365,7 +368,7 @@ webhooks:
       matchLabels:
         opa-istio-injection: enabled
     failurePolicy: Fail
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
 ############################################################


### PR DESCRIPTION
### What this PR does / why we need it:

I would like to propose that the apiVersion for AdmissionReview  be `admission.k8s.io/v1` instead of `admission.k8s.io/v1beta1`.





### FYI

`admission.k8s.io/v1beta1` has been removed in kubernetes docs. ( [PR](https://github.com/kubernetes/website/pull/34740/files#diff-8d3572c3fbe3cbb614db00cf1b0b090f4d7145484c9da027a1498478e0315393L409) )