### PR TITLE
build: switch base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,17 +97,17 @@ image-static:
 
 image-quick:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
-	docker build -t $(IMAGE):$(VERSION) --build-arg BASE=gcr.io/distroless/cc -f .Dockerfile_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION) --build-arg BASE=cgr.dev/chainguard/glibc-dynamic -f .Dockerfile_$(GOARCH) .
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):$(VERSION_ISTIO)
 
 image-quick-rootless:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
-	docker build -t $(IMAGE):$(VERSION)-rootless --build-arg USER=1000 --build-arg BASE=gcr.io/distroless/cc -f .Dockerfile_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION)-rootless --build-arg USER=1000 --build-arg BASE=cgr.dev/chainguard/glibc-dynamic -f .Dockerfile_$(GOARCH) .
 	docker tag $(IMAGE):$(VERSION)-rootless $(IMAGE):$(VERSION_ISTIO)-rootless
 
 image-quick-static:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
-	docker build -t $(IMAGE):$(VERSION)-static --build-arg BASE=gcr.io/distroless/static -f .Dockerfile_$(GOARCH) .
+	docker build -t $(IMAGE):$(VERSION)-static --build-arg BASE=cgr.dev/chainguard/static:latest -f .Dockerfile_$(GOARCH) .
 	docker tag $(IMAGE):$(VERSION)-static $(IMAGE):$(VERSION_ISTIO)-static
 
 push:


### PR DESCRIPTION
After bumping the golang version to 1.20.5, we started to see this:

    ./opa_envoy_linux_amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./opa_envoy_linux_amd64)
    ./opa_envoy_linux_amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./opa_envoy_linux_amd64)
    ./opa_envoy_linux_amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./opa_envoy_linux_amd64)

This was due to a glibc mismatch between the golang:1.20.5 image and the used base image (gcr.io/distroless).

Switching the base image to the same set of images that OPA uses resolves it.

👣 Try it locally:

1. `make image`
2. `docker run IMAGE version`