### PR TITLE
issue-4687 : Add B3 trace header propagation support 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
@@ -75,6 +74,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/contrib/propagators/b3 v1.21.1
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -231,6 +230,8 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.4
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1/go.mod h1:4UoMYEZOC0yN/sPGH76KPkkU7zgiEWYWL9vwmbnTJPE=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1/go.mod h1:sEGXWArGqc3tVa+ekntsN65DmVbVeW+7lTKTjZF3/Fo=
+go.opentelemetry.io/contrib/propagators/b3 v1.21.1 h1:WPYiUgmw3+b7b3sQ1bFBFAf0q+Di9dvNc3AtYfnT4RQ=
+go.opentelemetry.io/contrib/propagators/b3 v1.21.1/go.mod h1:EmzokPoSqsYMBVK4nRnhsfm5mbn8J1eDuz/U1UaQaWg=
 go.opentelemetry.io/otel v1.21.0 h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 h1:cl5P5/GIfFh4t6xyruOgJP5QiA1pw4fYYdv6nc6CBWw=

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/LICENSE
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/b3_config.go
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/b3_config.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b3 // import "go.opentelemetry.io/contrib/propagators/b3"
+
+type config struct {
+	// InjectEncoding are the B3 encodings used when injecting trace
+	// information. If no encoding is specified (i.e. `B3Unspecified`)
+	// `B3SingleHeader` will be used as the default.
+	InjectEncoding Encoding
+}
+
+// Option interface used for setting optional config properties.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+// newConfig creates a new config struct and applies opts to it.
+func newConfig(opts ...Option) *config {
+	c := &config{}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}
+
+// Encoding is a bitmask representation of the B3 encoding type.
+type Encoding uint8
+
+// supports returns if e has o bit(s) set.
+func (e Encoding) supports(o Encoding) bool {
+	return e&o == o
+}
+
+const (
+	// B3Unspecified is an unspecified B3 encoding.
+	B3Unspecified Encoding = 0
+	// B3MultipleHeader is a B3 encoding that uses multiple headers to
+	// transmit tracing information all prefixed with `x-b3-`.
+	//    x-b3-traceid: {TraceId}
+	//    x-b3-parentspanid: {ParentSpanId}
+	//    x-b3-spanid: {SpanId}
+	//    x-b3-sampled: {SamplingState}
+	//    x-b3-flags: {DebugFlag}
+	B3MultipleHeader Encoding = 1 << iota
+	// B3SingleHeader is a B3 encoding that uses a single header named `b3`
+	// to transmit tracing information.
+	//    b3: {TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}
+	B3SingleHeader
+)
+
+// WithInjectEncoding sets the encoding the propagator will inject.
+// The encoding is interpreted as a bitmask. Therefore
+//
+//	WithInjectEncoding(B3SingleHeader | B3MultipleHeader)
+//
+// means the propagator will inject both single and multi B3 headers.
+func WithInjectEncoding(encoding Encoding) Option {
+	return optionFunc(func(c *config) {
+		c.InjectEncoding = encoding
+	})
+}

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/b3_propagator.go
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/b3_propagator.go
@@ -1,0 +1,342 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b3 // import "go.opentelemetry.io/contrib/propagators/b3"
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// Default B3 Header names.
+	b3ContextHeader      = "b3"
+	b3DebugFlagHeader    = "x-b3-flags"
+	b3TraceIDHeader      = "x-b3-traceid"
+	b3SpanIDHeader       = "x-b3-spanid"
+	b3SampledHeader      = "x-b3-sampled"
+	b3ParentSpanIDHeader = "x-b3-parentspanid"
+
+	b3TraceIDPadding = "0000000000000000"
+
+	// B3 Single Header encoding widths.
+	separatorWidth      = 1       // Single "-" character.
+	samplingWidth       = 1       // Single hex character.
+	traceID64BitsWidth  = 64 / 4  // 16 hex character Trace ID.
+	traceID128BitsWidth = 128 / 4 // 32 hex character Trace ID.
+	spanIDWidth         = 16      // 16 hex character ID.
+	parentSpanIDWidth   = 16      // 16 hex character ID.
+)
+
+var (
+	empty = trace.SpanContext{}
+
+	errInvalidSampledByte        = errors.New("invalid B3 Sampled found")
+	errInvalidSampledHeader      = errors.New("invalid B3 Sampled header found")
+	errInvalidTraceIDHeader      = errors.New("invalid B3 traceID header found")
+	errInvalidSpanIDHeader       = errors.New("invalid B3 spanID header found")
+	errInvalidParentSpanIDHeader = errors.New("invalid B3 ParentSpanID header found")
+	errInvalidScope              = errors.New("require either both traceID and spanID or none")
+	errInvalidScopeParent        = errors.New("traceID and spanID required for ParentSpanID")
+	errInvalidScopeParentSingle  = errors.New("traceID, spanID and Sampled required for ParentSpanID")
+	errEmptyContext              = errors.New("empty request context")
+	errInvalidTraceIDValue       = errors.New("invalid B3 traceID value found")
+	errInvalidSpanIDValue        = errors.New("invalid B3 spanID value found")
+	errInvalidParentSpanIDValue  = errors.New("invalid B3 ParentSpanID value found")
+)
+
+type propagator struct {
+	cfg config
+}
+
+var _ propagation.TextMapPropagator = propagator{}
+
+// New creates a B3 implementation of propagation.TextMapPropagator.
+// B3 propagator serializes SpanContext to/from B3 Headers.
+// This propagator supports both versions of B3 headers,
+//  1. Single Header:
+//     b3: {TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}
+//  2. Multiple Headers:
+//     x-b3-traceid: {TraceId}
+//     x-b3-parentspanid: {ParentSpanId}
+//     x-b3-spanid: {SpanId}
+//     x-b3-sampled: {SamplingState}
+//     x-b3-flags: {DebugFlag}
+//
+// The Single Header propagator is used by default.
+func New(opts ...Option) propagation.TextMapPropagator {
+	cfg := newConfig(opts...)
+	return propagator{
+		cfg: *cfg,
+	}
+}
+
+// Inject injects a context into the carrier as B3 headers.
+// The parent span ID is omitted because it is not tracked in the
+// SpanContext.
+func (b3 propagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	sc := trace.SpanFromContext(ctx).SpanContext()
+
+	if b3.cfg.InjectEncoding.supports(B3SingleHeader) || b3.cfg.InjectEncoding == B3Unspecified {
+		header := []string{}
+		if sc.TraceID().IsValid() && sc.SpanID().IsValid() {
+			header = append(header, sc.TraceID().String(), sc.SpanID().String())
+		}
+
+		if debugFromContext(ctx) {
+			header = append(header, "d")
+		} else if !(deferredFromContext(ctx)) {
+			if sc.IsSampled() {
+				header = append(header, "1")
+			} else {
+				header = append(header, "0")
+			}
+		}
+
+		carrier.Set(b3ContextHeader, strings.Join(header, "-"))
+	}
+
+	if b3.cfg.InjectEncoding.supports(B3MultipleHeader) {
+		if sc.TraceID().IsValid() && sc.SpanID().IsValid() {
+			carrier.Set(b3TraceIDHeader, sc.TraceID().String())
+			carrier.Set(b3SpanIDHeader, sc.SpanID().String())
+		}
+
+		if debugFromContext(ctx) {
+			// Since Debug implies deferred, don't also send "X-B3-Sampled".
+			carrier.Set(b3DebugFlagHeader, "1")
+		} else if !(deferredFromContext(ctx)) {
+			if sc.IsSampled() {
+				carrier.Set(b3SampledHeader, "1")
+			} else {
+				carrier.Set(b3SampledHeader, "0")
+			}
+		}
+	}
+}
+
+// Extract extracts a context from the carrier if it contains B3 headers.
+func (b3 propagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	var (
+		sc  trace.SpanContext
+		err error
+	)
+
+	// Default to Single Header if a valid value exists.
+	if h := carrier.Get(b3ContextHeader); h != "" {
+		ctx, sc, err = extractSingle(ctx, h)
+		if err == nil && sc.IsValid() {
+			return trace.ContextWithRemoteSpanContext(ctx, sc)
+		}
+		// The Single Header value was invalid, fallback to Multiple Header.
+	}
+
+	var (
+		traceID      = carrier.Get(b3TraceIDHeader)
+		spanID       = carrier.Get(b3SpanIDHeader)
+		parentSpanID = carrier.Get(b3ParentSpanIDHeader)
+		sampled      = carrier.Get(b3SampledHeader)
+		debugFlag    = carrier.Get(b3DebugFlagHeader)
+	)
+	ctx, sc, err = extractMultiple(ctx, traceID, spanID, parentSpanID, sampled, debugFlag)
+	if err != nil || !sc.IsValid() {
+		// clear the deferred flag if we don't have a valid SpanContext
+		return withDeferred(ctx, false)
+	}
+	return trace.ContextWithRemoteSpanContext(ctx, sc)
+}
+
+func (b3 propagator) Fields() []string {
+	header := []string{}
+	if b3.cfg.InjectEncoding.supports(B3SingleHeader) {
+		header = append(header, b3ContextHeader)
+	}
+	if b3.cfg.InjectEncoding.supports(B3MultipleHeader) || b3.cfg.InjectEncoding == B3Unspecified {
+		header = append(header, b3TraceIDHeader, b3SpanIDHeader, b3SampledHeader, b3DebugFlagHeader)
+	}
+	return header
+}
+
+// extractMultiple reconstructs a SpanContext from header values based on B3
+// Multiple header. It is based on the implementation found here:
+// https://github.com/openzipkin/zipkin-go/blob/v0.2.2/propagation/b3/spancontext.go
+// and adapted to support a SpanContext.
+func extractMultiple(ctx context.Context, traceID, spanID, parentSpanID, sampled, flags string) (context.Context, trace.SpanContext, error) {
+	var (
+		err           error
+		requiredCount int
+		scc           = trace.SpanContextConfig{}
+	)
+
+	// correct values for an existing sampled header are "0" and "1".
+	// For legacy support and  being lenient to other tracing implementations we
+	// allow "true" and "false" as inputs for interop purposes.
+	switch strings.ToLower(sampled) {
+	case "0", "false":
+		// Zero value for TraceFlags sample bit is unset.
+	case "1", "true":
+		scc.TraceFlags = trace.FlagsSampled
+	case "":
+		ctx = withDeferred(ctx, true)
+	default:
+		return ctx, empty, errInvalidSampledHeader
+	}
+
+	// The only accepted value for Flags is "1". This will set Debug bitmask and
+	// sampled bitmask to 1 since debug implicitly means sampled. All other
+	// values and omission of header will be ignored. According to the spec. User
+	// shouldn't send X-B3-Sampled header along with X-B3-Flags header. Thus we will
+	// ignore X-B3-Sampled header when X-B3-Flags header is sent and valid.
+	if flags == "1" {
+		ctx = withDeferred(ctx, false)
+		ctx = withDebug(ctx, true)
+		scc.TraceFlags |= trace.FlagsSampled
+	}
+
+	if traceID != "" {
+		requiredCount++
+		id := traceID
+		if len(traceID) == 16 {
+			// Pad 64-bit trace IDs.
+			id = b3TraceIDPadding + traceID
+		}
+		if scc.TraceID, err = trace.TraceIDFromHex(id); err != nil {
+			return ctx, empty, errInvalidTraceIDHeader
+		}
+	}
+
+	if spanID != "" {
+		requiredCount++
+		if scc.SpanID, err = trace.SpanIDFromHex(spanID); err != nil {
+			return ctx, empty, errInvalidSpanIDHeader
+		}
+	}
+
+	if requiredCount != 0 && requiredCount != 2 {
+		return ctx, empty, errInvalidScope
+	}
+
+	if parentSpanID != "" {
+		if requiredCount == 0 {
+			return ctx, empty, errInvalidScopeParent
+		}
+		// Validate parent span ID but we do not use it so do not save it.
+		if _, err = trace.SpanIDFromHex(parentSpanID); err != nil {
+			return ctx, empty, errInvalidParentSpanIDHeader
+		}
+	}
+
+	return ctx, trace.NewSpanContext(scc), nil
+}
+
+// extractSingle reconstructs a SpanContext from contextHeader based on a B3
+// Single header. It is based on the implementation found here:
+// https://github.com/openzipkin/zipkin-go/blob/v0.2.2/propagation/b3/spancontext.go
+// and adapted to support a SpanContext.
+func extractSingle(ctx context.Context, contextHeader string) (context.Context, trace.SpanContext, error) {
+	if contextHeader == "" {
+		return ctx, empty, errEmptyContext
+	}
+
+	var (
+		scc      = trace.SpanContextConfig{}
+		sampling string
+	)
+
+	headerLen := len(contextHeader)
+
+	switch {
+	case headerLen == samplingWidth:
+		sampling = contextHeader
+	case headerLen == traceID64BitsWidth || headerLen == traceID128BitsWidth:
+		// Trace ID by itself is invalid.
+		return ctx, empty, errInvalidScope
+	case headerLen >= traceID64BitsWidth+spanIDWidth+separatorWidth:
+		pos := 0
+		var traceID string
+		switch {
+		case string(contextHeader[traceID64BitsWidth]) == "-":
+			// traceID must be 64 bits
+			pos += traceID64BitsWidth // {traceID}
+			traceID = b3TraceIDPadding + string(contextHeader[0:pos])
+		case string(contextHeader[32]) == "-":
+			// traceID must be 128 bits
+			pos += traceID128BitsWidth // {traceID}
+			traceID = string(contextHeader[0:pos])
+		default:
+			return ctx, empty, errInvalidTraceIDValue
+		}
+		var err error
+		scc.TraceID, err = trace.TraceIDFromHex(traceID)
+		if err != nil {
+			return ctx, empty, errInvalidTraceIDValue
+		}
+		pos += separatorWidth // {traceID}-
+
+		scc.SpanID, err = trace.SpanIDFromHex(contextHeader[pos : pos+spanIDWidth])
+		if err != nil {
+			return ctx, empty, errInvalidSpanIDValue
+		}
+		pos += spanIDWidth // {traceID}-{spanID}
+
+		if headerLen > pos {
+			if headerLen == pos+separatorWidth {
+				// {traceID}-{spanID}- is invalid.
+				return ctx, empty, errInvalidSampledByte
+			}
+			pos += separatorWidth // {traceID}-{spanID}-
+
+			switch {
+			case headerLen == pos+samplingWidth:
+				sampling = string(contextHeader[pos])
+			case headerLen == pos+parentSpanIDWidth:
+				// {traceID}-{spanID}-{parentSpanID} is invalid.
+				return ctx, empty, errInvalidScopeParentSingle
+			case headerLen == pos+samplingWidth+separatorWidth+parentSpanIDWidth:
+				sampling = string(contextHeader[pos])
+				pos += samplingWidth + separatorWidth // {traceID}-{spanID}-{sampling}-
+
+				// Validate parent span ID but we do not use it so do not
+				// save it.
+				_, err = trace.SpanIDFromHex(contextHeader[pos:])
+				if err != nil {
+					return ctx, empty, errInvalidParentSpanIDValue
+				}
+			default:
+				return ctx, empty, errInvalidParentSpanIDValue
+			}
+		}
+	default:
+		return ctx, empty, errInvalidTraceIDValue
+	}
+	switch sampling {
+	case "":
+		ctx = withDeferred(ctx, true)
+	case "d":
+		ctx = withDebug(ctx, true)
+		scc.TraceFlags = trace.FlagsSampled
+	case "1":
+		scc.TraceFlags = trace.FlagsSampled
+	case "0":
+		// Zero value for TraceFlags sample bit is unset.
+	default:
+		return ctx, empty, errInvalidSampledByte
+	}
+
+	return ctx, trace.NewSpanContext(scc), nil
+}

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/context.go
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/context.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b3 // import "go.opentelemetry.io/contrib/propagators/b3"
+
+import "context"
+
+type b3KeyType int
+
+const (
+	debugKey b3KeyType = iota
+	deferredKey
+)
+
+// withDebug returns a copy of parent with debug set as the debug flag value .
+func withDebug(parent context.Context, debug bool) context.Context {
+	return context.WithValue(parent, debugKey, debug)
+}
+
+// debugFromContext returns the debug value stored in ctx.
+//
+// If no debug value is stored in ctx false is returned.
+func debugFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	if debug, ok := ctx.Value(debugKey).(bool); ok {
+		return debug
+	}
+	return false
+}
+
+// withDeferred returns a copy of parent with deferred set as the deferred flag value .
+func withDeferred(parent context.Context, deferred bool) context.Context {
+	return context.WithValue(parent, deferredKey, deferred)
+}
+
+// deferredFromContext returns the deferred value stored in ctx.
+//
+// If no deferred value is stored in ctx false is returned.
+func deferredFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	if deferred, ok := ctx.Value(deferredKey).(bool); ok {
+		return deferred
+	}
+	return false
+}

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/doc.go
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b3 implements the B3 propagator specification as defined at
+// https://github.com/openzipkin/b3-propagation
+package b3 // import "go.opentelemetry.io/contrib/propagators/b3"

--- a/vendor/go.opentelemetry.io/contrib/propagators/b3/version.go
+++ b/vendor/go.opentelemetry.io/contrib/propagators/b3/version.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b3 // import "go.opentelemetry.io/contrib/propagators/b3"
+
+// Version is the current release version of the B3 propagator.
+func Version() string {
+	return "1.21.1"
+	// This string is updated by the pre_release.sh script during release
+}
+
+// SemVersion is the semantic version to be supplied to tracer/meter creation.
+//
+// Deprecated: Use [Version] instead.
+func SemVersion() string {
+	return Version()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,3 @@
-# cloud.google.com/go/compute/metadata v0.2.3
-## explicit; go 1.19
 # github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 ## explicit; go 1.20
 github.com/AdaLogics/go-fuzz-headers
@@ -391,6 +389,9 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/inte
 ## explicit; go 1.20
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
+# go.opentelemetry.io/contrib/propagators/b3 v1.21.1
+## explicit; go 1.20
+go.opentelemetry.io/contrib/propagators/b3
 # go.opentelemetry.io/otel v1.21.0
 ## explicit; go 1.20
 go.opentelemetry.io/otel


### PR DESCRIPTION
add b3 propagators module and use it
add test to assert that x-b3-traceid is recognized by opa and traceid is logged in decision logs