### PR TITLE
Allow to set the decisionID from an external function

### DIFF
--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -35,13 +35,20 @@ type StopFunc = func()
 type TransactionCloser func(ctx context.Context, err error) error
 
 // NewEvalResult creates a new EvalResult and a StopFunc that is used to stop the timer for metrics
-func NewEvalResult() (*EvalResult, StopFunc, error) {
+func NewEvalResult(opts ...func(*EvalResult)) (*EvalResult, StopFunc, error) {
 	var err error
 
-	er := EvalResult{
+	er := &EvalResult{
 		Metrics: metrics.New(),
 	}
-	er.DecisionID, err = util.UUID4()
+
+	for _, opt := range opts {
+		opt(er)
+	}
+
+	if er.DecisionID == "" {
+		er.DecisionID, err = util.UUID4()
+	}
 
 	if err != nil {
 		return nil, nil, err
@@ -53,7 +60,7 @@ func NewEvalResult() (*EvalResult, StopFunc, error) {
 		_ = er.Metrics.Timer(metrics.ServerHandler).Stop()
 	}
 
-	return &er, stop, nil
+	return er, stop, nil
 }
 
 // GetTxn creates a read transaction suitable for the configured EvalResult object

--- a/envoyauth/response_test.go
+++ b/envoyauth/response_test.go
@@ -396,3 +396,23 @@ func TestGetDynamicMetadataWithBooleanDecision(t *testing.T) {
 		t.Fatalf("Expected no result but got %v", result)
 	}
 }
+
+func TestNewEvalResultWithDecisionID(t *testing.T) {
+	type Opt func(*EvalResult)
+
+	withDecisionID := func(decisionID string) Opt {
+		return func(result *EvalResult) {
+			result.DecisionID = decisionID
+		}
+	}
+
+	expectedDecisionID := "some-decision-id"
+
+	er, _, err := NewEvalResult(withDecisionID(expectedDecisionID))
+	if err != nil {
+		t.Fatalf("NewEvalResult() error = %v, wantErr %v", err, false)
+	}
+	if er.DecisionID != expectedDecisionID {
+		t.Errorf("Expected DecisionID to be '%v', got '%v'", expectedDecisionID, er.DecisionID)
+	}
+}


### PR DESCRIPTION
## Short description 
An improvement to allow sending the decision ID from outside avoiding the default UUID  generation [here](https://github.com/open-policy-agent/opa-envoy-plugin/blob/543adde23777f285a2e974b18d509642b3c3bf8d/envoyauth/response.go#L44)

## Expected behavior
Suggesting improvement will allow passing a function from outside which can operate on the result. Current behavior of the default UUID generation is left intact, unless the function set a decision ID.

## Additional context
In a benchmark test we noticed the UUID generation is comparatively costly. (Below image shows a branch of it.)

<img width="179" alt="Screenshot 2024-02-08 at 17 13 34" src="https://github.com/open-policy-agent/opa-envoy-plugin/assets/791850/e3c0ad3a-fcd2-45db-bb80-12b7df39efc3">

Hence it will benefit if we can send an externally generated ID and set it here, avoiding the costly operation.

CC: @mjungsbluth 