### PR TITLE
Specific response assertion error messages

### DIFF
--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -105,7 +105,7 @@ func (result *EvalResult) IsAllowed() (bool, error) {
 		}
 
 		if allowed, ok = val.(bool); !ok {
-			return false, fmt.Errorf("type assertion error")
+			return false, fmt.Errorf("type assertion error, expected allowed to be of type 'boolean' but got '%T'", val)
 		}
 
 		return allowed, nil
@@ -137,14 +137,14 @@ func (result *EvalResult) GetRequestHTTPHeadersToRemove() ([]string, error) {
 			for _, vval := range val {
 				header, ok := vval.(string)
 				if !ok {
-					return nil, fmt.Errorf("type assertion error")
+					return nil, fmt.Errorf("type assertion error, expected request_headers_to_remove value to be of type 'string' but got '%T'", vval)
 				}
 
 				headersToRemove = append(headersToRemove, header)
 			}
 			return headersToRemove, nil
 		default:
-			return nil, fmt.Errorf("type assertion error")
+			return nil, fmt.Errorf("type assertion error, expected request_headers_to_remove to be of type '[]string' but got '%T'", val)
 		}
 	}
 
@@ -244,7 +244,7 @@ func (result *EvalResult) GetResponseBody() (string, error) {
 	}
 
 	if body, ok = val.(string); !ok {
-		return "", fmt.Errorf("type assertion error")
+		return "", fmt.Errorf("type assertion error, expected body to be of type 'string' but got '%T'", val)
 	}
 
 	return body, nil
@@ -271,7 +271,7 @@ func (result *EvalResult) GetResponseHTTPStatus() (int, error) {
 		}
 
 		if statusCode, ok = val.(json.Number); !ok {
-			return status, fmt.Errorf("type assertion error")
+			return status, fmt.Errorf("type assertion error, expected http_status to be of type 'number' but got '%T'", val)
 		}
 
 		httpStatusCode, err := statusCode.Int64()
@@ -307,7 +307,7 @@ func (result *EvalResult) GetDynamicMetadata() (*_structpb.Struct, error) {
 
 		metadata, ok := val.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("type assertion error")
+			return nil, fmt.Errorf("type assertion error, expected dynamic_metadata to be of type 'object' but got '%T'", val)
 		}
 
 		return structpb.NewStruct(metadata)
@@ -369,7 +369,7 @@ func transformToHTTPHeaderFormat(input interface{}, result *http.Header) error {
 		for _, val := range input {
 			headers, ok := val.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("type assertion error")
+				return fmt.Errorf("type assertion error, expected headers to be of type 'object' but got '%T'", val)
 			}
 
 			err := takeResponseHeaders(headers, result)
@@ -385,7 +385,7 @@ func transformToHTTPHeaderFormat(input interface{}, result *http.Header) error {
 		}
 
 	default:
-		return fmt.Errorf("type assertion error")
+		return fmt.Errorf("type assertion error, expected headers to be of type 'object' but got '%T'", input)
 	}
 
 	return nil

--- a/envoyauth/response_test.go
+++ b/envoyauth/response_test.go
@@ -3,6 +3,7 @@ package envoyauth
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	_structpb "github.com/golang/protobuf/ptypes/struct"
@@ -26,6 +27,10 @@ func TestIsAllowed(t *testing.T) {
 	_, err = er.IsAllowed()
 	if err == nil {
 		t.Fatal("Expected error but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "but got 'int'") {
+		t.Fatal("Assertion error type reflection failed")
 	}
 
 	input["allowed"] = true
@@ -107,6 +112,21 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("type_assertion_error", func(t *testing.T) {
+		er := EvalResult{
+			Decision: map[string]interface{}{"request_headers_to_remove": 1},
+		}
+
+		_, err := er.GetRequestHTTPHeadersToRemove()
+		if err == nil {
+			t.Fatal("Expected error but got nil")
+		}
+
+		if !strings.Contains(err.Error(), "but got 'int'") {
+			t.Fatalf("Assertion error type reflection failed")
+		}
+	})
 }
 
 func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
@@ -295,9 +315,13 @@ func TestGetResponseBody(t *testing.T) {
 	}
 
 	input["body"] = 123
-	result, err = er.GetResponseBody()
+	_, err = er.GetResponseBody()
 	if err == nil {
 		t.Fatal("Expected error but got nil", err)
+	}
+
+	if !strings.Contains(err.Error(), "but got 'int'") {
+		t.Fatalf("Assertion error type reflection failed")
 	}
 }
 
@@ -317,19 +341,23 @@ func TestGetResponseHttpStatus(t *testing.T) {
 	}
 
 	input["http_status"] = true
-	result, err = er.GetResponseEnvoyHTTPStatus()
+	_, err = er.GetResponseEnvoyHTTPStatus()
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
 
+	if !strings.Contains(err.Error(), "but got 'bool'") {
+		t.Fatalf("Assertion error type reflection failed")
+	}
+
 	input["http_status"] = json.Number("1")
-	result, err = er.GetResponseEnvoyHTTPStatus()
+	_, err = er.GetResponseEnvoyHTTPStatus()
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
 
 	input["http_status"] = json.Number("9999")
-	result, err = er.GetResponseEnvoyHTTPStatus()
+	_, err = er.GetResponseEnvoyHTTPStatus()
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
@@ -379,6 +407,16 @@ func TestGetDynamicMetadata(t *testing.T) {
 	}
 	if !proto.Equal(result, expectedDynamicMetadata) {
 		t.Fatalf("Expected result %v but got %v", expectedDynamicMetadata, result)
+	}
+
+	input["dynamic_metadata"] = 123
+	_, err = er.GetDynamicMetadata()
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "but got 'int'") {
+		t.Fatalf("Assertion error type reflection failed")
 	}
 }
 


### PR DESCRIPTION
I've been getting the error `"failed to get response body: type assertion error"` and it took me quite a while to figure out what the problem was. I've copied my policy into a playground and it worked fine there (in hindsight that's obvious).

I propose a more verbose and specific error message when assertion fails. I've taken the liberty to come with some suggestions.