### PR TITLE
Remove rootless images from build process 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,11 @@ FROM ${BASE}
 
 # Any non-zero number will do, and unfortunately a named user will not, as k8s
 # pod securityContext runAsNonRoot can't resolve the user ID:
-# https://github.com/kubernetes/kubernetes/issues/40958. Make root (uid 0) when
-# not specified.
-ARG USER=0
+# https://github.com/kubernetes/kubernetes/issues/40958.
+ARG USER=1000:1000
+USER ${USER}
 
 MAINTAINER Ashutosh Narkar  <anarkar4387@gmail.com>
-
-USER ${USER}
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
 	-X github.com/open-policy-agent/opa/version.Hostname=$(BUILD_HOSTNAME)"
 
 .PHONY: all build build-darwin build-linux build-linux-static build-windows clean check check-fmt check-vet check-lint \
-    deploy-ci docker-login generate image image-quick image-rootless image-quick-rootless image-static image-quick-static \
-    push push-rootless push-static push-latest push-latest-rootless push-latest-static tag-latest tag-latest-rootless \
+    deploy-ci docker-login generate image image-quick image-static image-quick-static \
+    push push-static push-latest push-latest-static tag-latest \
     tag-latest-static test test-cluster test-e2e version
 
 ######################################################
@@ -87,10 +87,6 @@ image:
 	@$(MAKE) ci-go-build-linux
 	@$(MAKE) image-quick
 
-image-rootless:
-	@$(MAKE) ci-go-build-linux
-	@$(MAKE) image-quick-rootless
-
 image-static:
 	CGO_ENABLED=0 WASM_ENABLED=0 $(MAKE) ci-go-build-linux-static
 	@$(MAKE) image-quick-static
@@ -99,11 +95,6 @@ image-quick:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
 	docker build -t $(IMAGE):$(VERSION) --build-arg BASE=cgr.dev/chainguard/glibc-dynamic -f .Dockerfile_$(GOARCH) .
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):$(VERSION_ISTIO)
-
-image-quick-rootless:
-	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
-	docker build -t $(IMAGE):$(VERSION)-rootless --build-arg USER=1000:1000 --build-arg BASE=cgr.dev/chainguard/glibc-dynamic -f .Dockerfile_$(GOARCH) .
-	docker tag $(IMAGE):$(VERSION)-rootless $(IMAGE):$(VERSION_ISTIO)-rootless
 
 image-quick-static:
 	sed -e 's/GOARCH/$(GOARCH)/g' Dockerfile > .Dockerfile_$(GOARCH)
@@ -114,10 +105,6 @@ push:
 	docker push $(IMAGE):$(VERSION)
 	docker push $(IMAGE):$(VERSION_ISTIO)
 
-push-rootless:
-	docker push $(IMAGE):$(VERSION)-rootless
-	docker push $(IMAGE):$(VERSION_ISTIO)-rootless
-
 push-static:
 	docker push $(IMAGE):$(VERSION)-static
 	docker push $(IMAGE):$(VERSION_ISTIO)-static
@@ -125,10 +112,6 @@ push-static:
 tag-latest:
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest-envoy
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest-istio
-
-tag-latest-rootless:
-	docker tag $(IMAGE):$(VERSION)-rootless $(IMAGE):latest-envoy-rootless
-	docker tag $(IMAGE):$(VERSION)-rootless $(IMAGE):latest-istio-rootless
 
 tag-latest-static:
 	docker tag $(IMAGE):$(VERSION)-static $(IMAGE):latest-envoy-static
@@ -138,10 +121,6 @@ push-latest:
 	docker push $(IMAGE):latest-envoy
 	docker push $(IMAGE):latest-istio
 
-push-latest-rootless:
-	docker push $(IMAGE):latest-envoy-rootless
-	docker push $(IMAGE):latest-istio-rootless
-
 push-latest-static:
 	docker push $(IMAGE):latest-envoy-static
 	docker push $(IMAGE):latest-istio-static
@@ -150,8 +129,8 @@ docker-login:
 	@echo "Docker Login..."
 	@echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USER} --password-stdin
 
-deploy-ci: docker-login image image-rootless image-static push tag-latest push-latest push-rootless tag-latest-rootless \
-	push-latest-rootless push-static tag-latest-static push-latest-static
+deploy-ci: docker-login image image-static push tag-latest push-latest \
+	push-static tag-latest-static push-latest-static
 
 test: generate
 	$(DISABLE_CGO) $(GO) test -v -bench=. $(PACKAGES)


### PR DESCRIPTION
Resolves https://github.com/open-policy-agent/opa/issues/6810 by removing rootless images from the `Makefile`, and thus, from the build/release process for `opa-envoy-plugin`.