### PR TITLE
feat: Fixed expired jwt token in envoy-uds example

### DIFF
--- a/examples/envoy-uds/README.md
+++ b/examples/envoy-uds/README.md
@@ -58,7 +58,7 @@ echo $SERVICE_URL
 For convenience, we’ll want to store Alice’s token in environment variables.
 
 ```bash
-export ALICE_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiZ3Vlc3QiLCJzdWIiOiJZV3hwWTJVPSIsIm5iZiI6MTUxNDg1MTEzOSwiZXhwIjoxNjQxMDgxNTM5fQ.K5DnnbbIOspRbpCr2IKXE9cPVatGOCBrBQobQmBmaeU"
+export ALICE_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIyNDEwODE1MzksIm5iZiI6MTUxNDg1MTEzOSwicm9sZSI6Imd1ZXN0Iiwic3ViIjoiWVd4cFkyVT0ifQ.ja1bgvIt47393ba_WbSBm35NrUhdxM4mOVQN8iXz8lk"
 ```
 
 Check that `Alice` can get employees **but cannot** create one.


### PR DESCRIPTION
Close : [#6757](https://github.com/open-policy-agent/opa/issues/6757#issuecomment-2198106398) 

The JWT token was used to demonstrate the example was expired.