### PR TITLE
Upgrade CI dependencies for testing

### DIFF
--- a/build/install-istio-with-kind.sh
+++ b/build/install-istio-with-kind.sh
@@ -6,8 +6,8 @@ set -x
 
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
-KIND_VERSION=0.11.1
-ISTIO_VERSION=1.19.4
+KIND_VERSION=0.23.0
+ISTIO_VERSION=1.22.3
 
 # Download and install kind
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${GOOS}-${GOARCH} --output kind && chmod +x kind && sudo mv kind /usr/local/bin/

--- a/examples/grpc/docker-compose.yaml
+++ b/examples/grpc/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   envoy:
-    image: envoyproxy/envoy:v1.26-latest
+    image: envoyproxy/envoy:v1.31-latest
     ports:
       - "9901:9901"
       - "51051:51051"


### PR DESCRIPTION
Istio 1.19.4 (the current test target) is EOL at this point. This PR upgrades the test version for Istio CI tests to 1.22.3, which is latest. See https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases for more.  In the process, I also upgraded `kind` to latest, as the `0.11` kubernetes version (1.21) is no longer supported by the Istio project.

While updating this, I noticed that our test version of Envoy was 1.26, which is also unsupported: https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history, so I fixed that as well.

I don't believe we need to bump these versions after every Istio or Envoy patch/minor release, but it would be nice to make sure that we're still testing against maintained versions.