### PR TITLE
examples/grpc: Move to Docker Compose v2

### DIFF
--- a/examples/grpc/Makefile
+++ b/examples/grpc/Makefile
@@ -14,12 +14,12 @@ testsrv.pb: testsrv/test.proto
 
 .PHONY: test-setup
 test-setup:
-	docker-compose up -d
+	docker compose up -d
 
 .PHONY: test-teardown
 test-teardown:
-	docker-compose logs
-	docker-compose down
+	docker compose logs
+	docker compose down
 
 .PHONY: test
 test:

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -20,7 +20,7 @@ The docker-compose.yaml file defines three services:
          pack_as_bytes: true
    ```
 
-After spinning them up with `docker-compose up`, they can be exercised
+After spinning them up with `docker compose up`, they can be exercised
 using a gRPC client.
 
 This is an example invocation using `grpcurl`:


### PR DESCRIPTION
Migrate to Docker Compose v2 as Docker Compose v1 removed from GitHub Actions runners. Ref: https://github.com/actions/runner-images/issues/9692