### PR TITLE
Enable linux arm builds for OPA envoy plugin

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build docker image
-        run: make ci-go-build image-quick tag-latest
+        run: make ci-go-build ci-go-build-linux-static image-quick tag-latest
 
       - name: Setup kind/istio
         run: |
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build docker image
-        run: make ci-go-build image-quick tag-latest
+        run: make ci-go-build ci-go-build-linux-static image-quick tag-latest
 
       - name: Build testsrv docker image
         run: make testsrv-image

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ opa_*
 _release
 site.tar.gz
 *.bak
+.go/
 
 # runtime artifacts
 policies

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,23 @@ ARG BASE
 
 FROM ${BASE}
 
+LABEL org.opencontainers.image.authors="Ashutosh Narkar <anrkar4387@gmail.com>"
+
 # Any non-zero number will do, and unfortunately a named user will not, as k8s
 # pod securityContext runAsNonRoot can't resolve the user ID:
 # https://github.com/kubernetes/kubernetes/issues/40958.
 ARG USER=1000:1000
 USER ${USER}
 
-MAINTAINER Ashutosh Narkar  <anarkar4387@gmail.com>
+# TARGETOS and TARGETARCH are automatic platform args injected by BuildKit
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETOS
+ARG TARGETARCH
+# VARIANT is used to specify the build variant of the image, e.g. static or dynamic
+ARG VARIANT
 
-WORKDIR /app
+COPY opa_envoy_${TARGETOS}_${TARGETARCH}_${VARIANT} /opa
 
-COPY opa_envoy_linux_GOARCH /app
-
-ENTRYPOINT ["./opa_envoy_linux_GOARCH"]
+ENTRYPOINT ["/opa"]
 
 CMD ["run"]

--- a/build/ensure-linux-toolchain.sh
+++ b/build/ensure-linux-toolchain.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+case "$(uname -m | tr '[:upper:]' '[:lower:]')" in
+  amd64 | x86_64 | x64)
+    HOST_ARCH=amd64
+    ;;
+  arm64 | aarch64)
+    HOST_ARCH=arm64
+    ;;
+  *)
+    echo "Error: Host architecture not supported." >&2
+    exit 1
+    ;;
+esac
+
+# Native build
+if [ "${GOARCH}" = "${HOST_ARCH}" ]; then
+  if ! [ -x "$(command -v gcc)" ]; then
+    echo "Error: gcc not found." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Cross-compile
+case "${GOARCH}" in
+  amd64)
+    PKG=gcc-x86-64-linux-gnu
+    CC=x86_64-linux-gnu-gcc
+    ;;
+  arm64)
+    PKG=gcc-aarch64-linux-gnu
+    CC=aarch64-linux-gnu-gcc
+    ;;
+  *)
+    echo "Error: Target architecture ${GOARCH} not supported." >&2
+    exit 1
+    ;;
+esac
+
+type -f ${CC} 2>/dev/null && exit 0
+
+if ! [ -x "$(command -v apt-get)" ]; then
+  echo "Error: apt-get not found. Could not install missing toolchain." >&2
+  exit 1
+fi
+
+apt-get update >/dev/null && \
+  apt-get install -y ${PKG} >/dev/null
+
+echo ${CC}

--- a/build/get-plugin-rev.sh
+++ b/build/get-plugin-rev.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Script to get number of commits from the last OPA revendoring
 
+# trust our mounted directory
+git config --global --add safe.directory /src
+
 LINE=$(git grep -n "github.com/open-policy-agent/opa " go.mod | awk -F: '{ print $2 }')
 GIT_SHA=$(git log -n 1 --pretty=format:%H -L $LINE,$LINE:go.mod | head -1)
 COMMITS=$(git rev-list $GIT_SHA..HEAD --count)


### PR DESCRIPTION
This PR resolves https://github.com/open-policy-agent/opa/issues/4965 by adding ARM builds to the CI process. `make deploy-ci` will now build binaries, start a docker builder for cross-platform builds and push manifests for static and dynamic multiarch builds.

You can see the results here in my docker hub repository: https://hub.docker.com/repository/docker/tylerschade268/opa/tags.

I'm no expert on build tooling so all suggestions are welcome. I consider this a first draft rather than a "please merge immediately" PR.

This Makefile is definitely a little messy and I question whether we need all of these targets as some of them don't seem necessary anymore. I also question if we need different tags for Istio and Envoy as the images are identical. Regardless, I'd like to leave both of those questions for another day.