### PR TITLE
cmd: avoid panic when starting with a bad config

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -333,6 +333,7 @@ func (p *envoyExtAuthzGrpcServer) listen() {
 
 	if err != nil {
 		logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to create listener.")
+		return
 	}
 
 	logger.WithFields(map[string]interface{}{


### PR DESCRIPTION
Previously, if you ran opa-envoy-plugin wiht a bad config like this:

    plugins:
      envoy_ext_authz_grpc:
        addr: "127.0.0.1:9090:"

You'd run into a panic:

```
{"err":"listen tcp: address 127.0.0.1:9090:: too many colons in address","level":"error","msg":"Unable to create listener.","time":"2024-09-25T10:48:55+02:00"}
{"addr":"127.0.0.1:9090:","dry-run":false,"enable-reflection":false,"level":"info","msg":"Starting gRPC server.","path":"envoy/authz/allow","query":"","time":"2024-09-25T10:48:55+02:00"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xbc569ea]

goroutine 14 [running]:
google.golang.org/grpc.(*Server).Serve(0xc000544c00, {0x0, 0x0})
	/Users/stephan/Sources/open-policy-agent/opa-envoy-plugin/vendor/google.golang.org/grpc/server.go:863 +0x16a
github.com/open-policy-agent/opa-envoy-plugin/internal.(*envoyExtAuthzGrpcServer).listen(0xc0004fe690)
	/Users/stephan/Sources/open-policy-agent/opa-envoy-plugin/internal/internal.go:348 +0x630
created by github.com/open-policy-agent/opa-envoy-plugin/internal.(*envoyExtAuthzGrpcServer).Start in goroutine 1
	/Users/stephan/Sources/open-policy-agent/opa-envoy-plugin/internal/internal.go:284 +0xba
```

With this change, the behaviour is the same as for a bad url: the error is logged, and the plugin fails to become ready.

I think it would be better to error out, but that would require some deeper refactoring. At least now, we'll avoid the panic.