### PR TITLE
Refactor creation of prepared queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Refactor creation of prepared queries (#604, @mjungsbluth)
+  
+  When using the opa-envoy-plugin as a Go library, the interface EvalContext contains a breaking change [#604](https://github.com/open-policy-agent/opa-envoy-plugin/pull/604) that allows users of the library to control all three types of options that can be passed during preparation and evaluation of the underlying Rego query.  
+
 ### Fixes
 
 - Support escaped forward-slashes (`\/`) in JSON request bodies (#256, @Dakatan).


### PR DESCRIPTION
Before this refactoring only the PreparedQuery options could be passed when using this plugin as a library. There are two more options (prepare options and evaluation options) that can be passed when using the OPA library directly.

This change breaks the interface but also allows for extensibility of creating the prepared queries in the future.
