### PR TITLE
MAINTAINERS: Add Tyler to the list of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,4 @@
 # Maintainers
 
-- Ashutosh Narkar (anarkar4387@gmail.com) 
+- Ashutosh Narkar, Styra (anarkar4387@gmail.com)
+- Tyler Schade, GEICO Tech (tylerschade99@gmail.com)

--- a/README.md
+++ b/README.md
@@ -190,3 +190,7 @@ Dependencies are managed with [Modules](https://github.com/golang/go/wiki/Module
 If you need to add or update dependencies, modify the `go.mod` file or
 use `go get`. More information is available [here](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies).
 Finally commit all changes to the repository.
+
+## Maintainers
+
+Please see the [MAINTAINERS.md](./MAINTAINERS.md) file for maintainer details.


### PR DESCRIPTION
Tyler has been consistently involved for some time and we'd like to main Tyler a maintainer of the opa-envoy-plugin project.

Tyler is being adding under this clause in the opa project governance: https://github.com/open-policy-agent/opa/blob/main/GOVERNANCE.md#github-project-administration