### PR TITLE
feat: return query_parameters_to_remove with OkResponse

### DIFF
--- a/envoyauth/response_test.go
+++ b/envoyauth/response_test.go
@@ -46,6 +46,74 @@ func TestIsAllowed(t *testing.T) {
 	}
 }
 
+func TestGetRequestQueryParametersToRemove(t *testing.T) {
+	tests := map[string]struct {
+		decision interface{}
+		exp      []string
+		wantErr  bool
+	}{
+		"bool_eval_result": {
+			true,
+			nil,
+			false,
+		},
+		"invalid_eval_result": {
+			"hello",
+			nil,
+			true,
+		},
+		"empty_map_result": {
+			map[string]interface{}{},
+			nil,
+			false,
+		},
+		"bad_param_value": {
+			map[string]interface{}{"query_parameters_to_remove": "test"},
+			nil,
+			true,
+		},
+		"string_array_param_value": {
+			map[string]interface{}{"query_parameters_to_remove": []string{"foo", "bar"}},
+			[]string{"foo", "bar"},
+			false,
+		},
+		"interface_array_param_value": {
+			map[string]interface{}{"query_parameters_to_remove": []interface{}{"foo", "bar", "fuz"}},
+			[]string{"foo", "bar", "fuz"},
+			false,
+		},
+		"interface_array_bad_param_value": {
+			map[string]interface{}{"query_parameters_to_remove": []interface{}{1}},
+			nil,
+			true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			er := EvalResult{
+				Decision: tc.decision,
+			}
+
+			result, err := er.GetRequestQueryParametersToRemove()
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+
+				if !reflect.DeepEqual(tc.exp, result) {
+					t.Fatalf("Expected result %v but got %v", tc.exp, result)
+				}
+			}
+		})
+	}
+}
+
 func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 	tests := map[string]struct {
 		decision interface{}
@@ -54,22 +122,22 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 	}{
 		"bool_eval_result": {
 			true,
-			[]string{},
+			nil,
 			false,
 		},
 		"invalid_eval_result": {
 			"hello",
-			[]string{},
+			nil,
 			true,
 		},
 		"empty_map_result": {
 			map[string]interface{}{},
-			[]string{},
+			nil,
 			false,
 		},
 		"bad_header_value": {
 			map[string]interface{}{"request_headers_to_remove": "test"},
-			[]string{},
+			nil,
 			true,
 		},
 		"string_array_header_value": {
@@ -84,7 +152,7 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 		},
 		"interface_array_bad_header_value": {
 			map[string]interface{}{"request_headers_to_remove": []interface{}{1}},
-			[]string{},
+			nil,
 			true,
 		},
 	}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -525,11 +525,20 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 				return nil, stop, internalErr
 			}
 
+			var queryParamsToRemove []string
+			queryParamsToRemove, err = result.GetRequestQueryParametersToRemove()
+			if err != nil {
+				err = errors.Wrap(err, "failed to get request query parameters to remove")
+				internalErr = newInternalError(EnvoyAuthResultErr, err)
+				return nil, stop, internalErr
+			}
+
 			resp.HttpResponse = &ext_authz_v3.CheckResponse_OkResponse{
 				OkResponse: &ext_authz_v3.OkHttpResponse{
-					Headers:              responseHeaders,
-					HeadersToRemove:      headersToRemove,
-					ResponseHeadersToAdd: responseHeadersToAdd,
+					Headers:                 responseHeaders,
+					HeadersToRemove:         headersToRemove,
+					ResponseHeadersToAdd:    responseHeadersToAdd,
+					QueryParametersToRemove: queryParamsToRemove,
 				},
 			}
 		} else {


### PR DESCRIPTION
Envoy External Auth v3 API supports the `query_parameters_to_remove` attribute with `OkResponse`.

See https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#service-auth-v3-okhttpresponse

The change allows to return from OPA which query parameters should be removed from the upstream query.