### PR TITLE
refact: avoid mem alloc with disabled decision log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ deploy-ci: docker-login ensure-release-dir start-builder ci-build-linux ci-build
 
 .PHONY: test
 test: generate
-	$(DISABLE_CGO) $(GO) test -v -bench=. $(PACKAGES)
+	$(DISABLE_CGO) $(GO) test -v -bench=. -benchmem $(PACKAGES)
 
 .PHONY: test-e2e
 test-e2e:

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -34,6 +34,10 @@ type StopFunc = func()
 // TransactionCloser should be called to abort the transaction
 type TransactionCloser func(ctx context.Context, err error) error
 
+func noopTransactionCloser(context.Context, error) error {
+	return nil // no-op default
+}
+
 // NewEvalResult creates a new EvalResult and a StopFunc that is used to stop the timer for metrics
 func NewEvalResult(opts ...func(*EvalResult)) (*EvalResult, StopFunc, error) {
 	var err error
@@ -67,13 +71,9 @@ func NewEvalResult(opts ...func(*EvalResult)) (*EvalResult, StopFunc, error) {
 func (result *EvalResult) GetTxn(ctx context.Context, store storage.Store) (storage.Transaction, TransactionCloser, error) {
 	params := storage.TransactionParams{}
 
-	noopCloser := func(ctx context.Context, err error) error {
-		return nil // no-op default
-	}
-
 	txn, err := store.NewTransaction(ctx, params)
 	if err != nil {
-		return nil, noopCloser, err
+		return nil, noopTransactionCloser, err
 	}
 
 	// Setup a closer function that will abort the transaction.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/open-policy-agent/opa-envoy-plugin
 
 go 1.22.0
+
 toolchain go1.23.1
 
 require (

--- a/internal/internal_bench_test.go
+++ b/internal/internal_bench_test.go
@@ -17,7 +17,28 @@ import (
 func BenchmarkCheck(b *testing.B) {
 	var req ext_authz.CheckRequest
 	if err := util.Unmarshal([]byte(exampleAllowedRequest), &req); err != nil {
-		panic(err)
+		b.Fatal(err)
+	}
+
+	server := testAuthzServer(nil)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		output, err := server.Check(ctx, &req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if output.Status.Code != int32(code.Code_OK) {
+			b.Fatal("Expected request to be allowed but got:", output)
+		}
+	}
+}
+
+func BenchmarkCheck_withCustomLogger(b *testing.B) {
+	var req ext_authz.CheckRequest
+	if err := util.Unmarshal([]byte(exampleAllowedRequest), &req); err != nil {
+		b.Fatal(err)
 	}
 
 	server := testAuthzServer(nil, withCustomLogger(&testPlugin{}))

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -2138,7 +2138,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 func TestLogWithASTError(t *testing.T) {
 	server := testAuthzServer(nil, withCustomLogger(&testPlugin{}))
-	err := server.log(context.Background(), nil, &envoyauth.EvalResult{}, &ast.Error{Code: "foo"})
+	err := server.logDecision(context.Background(), nil, &envoyauth.EvalResult{}, &ast.Error{Code: "foo"})
 	if err != nil {
 		panic(err)
 	}
@@ -2149,7 +2149,7 @@ func TestLogWithCancelError(t *testing.T) {
 	customLogger := &testPlugin{}
 
 	server := testAuthzServer(nil, withCustomLogger(customLogger))
-	err := server.log(context.Background(), nil, &envoyauth.EvalResult{}, &topdown.Error{
+	err := server.logDecision(context.Background(), nil, &envoyauth.EvalResult{}, &topdown.Error{
 		Code:    topdown.CancelErr,
 		Message: "caller cancelled query execution",
 	})

--- a/opa/decisionlog/decision_log.go
+++ b/opa/decisionlog/decision_log.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/open-policy-agent/opa-envoy-plugin/envoyauth"
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/plugins/logs"
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
@@ -21,15 +20,10 @@ func (e *internalError) Error() string {
 }
 
 // LogDecision - Logs a decision log event
-func LogDecision(ctx context.Context, manager *plugins.Manager, info *server.Info, result *envoyauth.EvalResult, err error) error {
-	plugin := logs.Lookup(manager)
-	if plugin == nil {
-		return nil
-	}
-
+func LogDecision(ctx context.Context, plugin *logs.Plugin, info *server.Info, result *envoyauth.EvalResult, err error) error {
 	info.Revision = result.Revision
 
-	bundles := map[string]server.BundleInfo{}
+	bundles := make(map[string]server.BundleInfo, len(result.Revisions))
 	for name, rev := range result.Revisions {
 		bundles[name] = server.BundleInfo{Revision: rev}
 	}


### PR DESCRIPTION
**Benchmark results**.

```
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/opa-envoy-plugin/internal
cpu: Apple M2 Pro
```

Before:
```
BenchmarkCheck-12             15540             80774 ns/op           55005 B/op       1090 allocs/op
```

After:
```
BenchmarkCheck-12             15696             80721 ns/op           54839 B/op       1087 allocs/op
```