### PR TITLE
refact: avoid mem alloc for debug log

### DIFF
--- a/envoyauth/evaluation.go
+++ b/envoyauth/evaluation.go
@@ -60,11 +60,13 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 
 	result.TxnID = result.Txn.ID()
 
-	logger.WithFields(map[string]interface{}{
-		"input": input,
-		"query": evalContext.ParsedQuery().String(),
-		"txn":   result.TxnID,
-	}).Debug("Executing policy query.")
+	if logger.GetLevel() == logging.Debug {
+		logger.WithFields(map[string]interface{}{
+			"input": input,
+			"query": evalContext.ParsedQuery().String(),
+			"txn":   result.TxnID,
+		}).Debug("Executing policy query.")
+	}
 
 	pq, err := evalContext.CreatePreparedQueryOnce(
 		PrepareQueryOpts{

--- a/envoyauth/evaluation_test.go
+++ b/envoyauth/evaluation_test.go
@@ -130,6 +130,7 @@ func TestEval(t *testing.T) {
 	ctx := context.Background()
 
 	logger := loggingtest.New()
+	logger.SetLevel(logging.Debug)
 	server, err := testAuthzServer(logger)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Each check request creates unnecessary memory garbage for the debug message, even when the log level is set higher than debug.

**Benchmark results.**

```
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/opa-envoy-plugin/internal
cpu: Apple M2 Pro
```

With `Debug`:
```
BenchmarkCheck-12            15576             78914 ns/op           54843 B/op       1088 allocs/op
```

Without `Debug`:
```
BenchmarkCheck-12            16891             75411 ns/op           51540 B/op       1037 allocs/op
```