### PR TITLE
refact: uuid func, new otelgrpc

### DIFF
--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -96,8 +96,9 @@ func getParsedPathAndQuery(path string) ([]interface{}, map[string]interface{}, 
 		parsedPathInterface[i] = v
 	}
 
-	parsedQueryInterface := make(map[string]interface{})
-	for paramKey, paramValues := range parsedURL.Query() {
+	query := parsedURL.Query()
+	parsedQueryInterface := make(map[string]interface{}, len(query))
+	for paramKey, paramValues := range query {
 		queryValues := make([]interface{}, len(paramValues))
 		for i, v := range paramValues {
 			queryValues[i] = v

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -10,7 +10,7 @@ import (
 	ext_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	_structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/open-policy-agent/opa-envoy-plugin/internal/util"
+	"github.com/google/uuid"
 	"github.com/open-policy-agent/opa/metrics"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown/builtins"
@@ -41,8 +41,6 @@ func noopTransactionCloser(context.Context, error) error {
 
 // NewEvalResult creates a new EvalResult and a StopFunc that is used to stop the timer for metrics
 func NewEvalResult(opts ...func(*EvalResult)) (*EvalResult, StopFunc, error) {
-	var err error
-
 	er := &EvalResult{
 		Metrics: metrics.New(),
 	}
@@ -52,11 +50,7 @@ func NewEvalResult(opts ...func(*EvalResult)) (*EvalResult, StopFunc, error) {
 	}
 
 	if er.DecisionID == "" {
-		er.DecisionID, err = util.UUID4()
-	}
-
-	if err != nil {
-		return nil, nil, err
+		er.DecisionID = uuid.NewString()
 	}
 
 	er.Metrics.Timer(metrics.ServerHandler).Start()

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v24.12.23+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -159,8 +159,7 @@ func New(m *plugins.Manager, cfg *Config) plugins.Plugin {
 			otelhttp.WithPropagators(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}, b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader|b3.B3SingleHeader)))),
 		)
 		grpcOpts = append(grpcOpts,
-			grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor(grpcTracingOption...)),
-			grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor(grpcTracingOption...)),
+			grpc.StatsHandler(otelgrpc.NewServerHandler(grpcTracingOption...)),
 		)
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,10 +1,7 @@
 package util
 
 import (
-	"crypto/rand"
-	"fmt"
-	"io"
-	"io/ioutil"
+	"os"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
@@ -14,7 +11,7 @@ import (
 
 // ReadProtoSet - Reads protobuf files from disk
 func ReadProtoSet(path string) (*protoregistry.Files, error) {
-	protoSet, err := ioutil.ReadFile(path)
+	protoSet, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -23,16 +20,4 @@ func ReadProtoSet(path string) (*protoregistry.Files, error) {
 		return nil, err
 	}
 	return protodesc.NewFiles(&fileSet)
-}
-
-// UUID4 Generates a new universally unique identifier
-func UUID4() (string, error) {
-	bs := make([]byte, 16)
-	n, err := io.ReadFull(rand.Reader, bs)
-	if n != len(bs) || err != nil {
-		return "", err
-	}
-	bs[8] = bs[8]&^0xc0 | 0x80
-	bs[6] = bs[6]&^0xf0 | 0x40
-	return fmt.Sprintf("%x-%x-%x-%x-%x", bs[0:4], bs[4:6], bs[6:8], bs[8:10], bs[10:]), nil
 }


### PR DESCRIPTION
1. Replace `util.UUID4` function by `google/uuid` package.
2. Replace some deprecation by new versions.

**Benchmark results**

Before:
```
BenchmarkCheck-12             22563             54552 ns/op           34918 B/op        697 allocs/op
```

After:
```
BenchmarkCheck-12             22776             53283 ns/op           34797 B/op        692 allocs/op
```