### PR TITLE
refact: read bundle revisions if decision log enabled

### DIFF
--- a/envoyauth/evaluation_test.go
+++ b/envoyauth/evaluation_test.go
@@ -2,7 +2,6 @@ package envoyauth
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -15,7 +14,6 @@ import (
 	"github.com/open-policy-agent/opa/plugins/logs"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/plugins"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
@@ -23,99 +21,6 @@ import (
 	iCache "github.com/open-policy-agent/opa/topdown/cache"
 	"github.com/open-policy-agent/opa/topdown/print"
 )
-
-func TestGetRevisionLegacy(t *testing.T) {
-	store := inmem.New()
-	ctx := context.Background()
-
-	result := EvalResult{}
-
-	tb := bundle.Manifest{
-		Revision: "abc123",
-		Roots:    &[]string{"/a/b", "/a/c"},
-	}
-
-	// write a "legacy" manifest
-	err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
-		if err := bundle.LegacyWriteManifestToStore(ctx, store, txn, tb); err != nil {
-			t.Fatalf("Failed to write manifest to store: %s", err)
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("Unexpected error finishing transaction: %s", err)
-	}
-
-	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
-
-	err = getRevision(ctx, store, txn, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := "abc123"
-	if result.Revision != "abc123" {
-		t.Fatalf("Expected revision %v but got %v", expected, result.Revision)
-	}
-
-	if len(result.Revisions) != 0 {
-		t.Fatal("Unexpected multiple bundles")
-	}
-}
-
-func TestGetRevisionMulti(t *testing.T) {
-	store := inmem.New()
-	ctx := context.Background()
-
-	result := EvalResult{}
-
-	bundles := map[string]bundle.Manifest{
-		"bundle1": {
-			Revision: "abc123",
-			Roots:    &[]string{"/a/b", "/a/c"},
-		},
-		"bundle2": {
-			Revision: "def123",
-			Roots:    &[]string{"/x/y", "/z"},
-		},
-	}
-
-	// write bundles
-	for name, manifest := range bundles {
-		err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
-			err := bundle.WriteManifestToStore(ctx, store, txn, name, manifest)
-			if err != nil {
-				t.Fatalf("Failed to write manifest to store: %s", err)
-			}
-			return err
-		})
-		if err != nil {
-			t.Fatalf("Unexpected error finishing transaction: %s", err)
-		}
-	}
-
-	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
-
-	err := getRevision(ctx, store, txn, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(result.Revisions) != 2 {
-		t.Fatalf("Expected two bundles but got %v", len(result.Revisions))
-	}
-
-	expected := map[string]string{"bundle1": "abc123", "bundle2": "def123"}
-	if !reflect.DeepEqual(result.Revisions, expected) {
-		t.Fatalf("Expected result: %v, got: %v", expected, result.Revisions)
-	}
-
-	if result.Revision != "" {
-		t.Fatalf("Unexpected revision %v", result.Revision)
-	}
-
-}
 
 type testPrintHook struct {
 	printed string
@@ -211,7 +116,7 @@ func testAuthzServer(logger logging.Logger) (*mockExtAuthzGrpcServer, error) {
 
 		default allow = false
 
-        allow {
+		allow {
 			input.parsed_body.firstname == "foo"
 			input.parsed_body.lastname == "bar"
 			print(input.parsed_body)

--- a/envoyauth/response_test.go
+++ b/envoyauth/response_test.go
@@ -1,12 +1,16 @@
 package envoyauth
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
 
 	_structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -43,6 +47,102 @@ func TestIsAllowed(t *testing.T) {
 
 	if result != true {
 		t.Fatalf("Expected value for IsAllowed %v but got %v", true, result)
+	}
+}
+
+func TestReadRevisionsLegacy(t *testing.T) {
+	store := inmem.New()
+	ctx := context.Background()
+
+	tb := bundle.Manifest{
+		Revision: "abc123",
+		Roots:    &[]string{"/a/b", "/a/c"},
+	}
+
+	// write a "legacy" manifest
+	err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		if err := bundle.LegacyWriteManifestToStore(ctx, store, txn, tb); err != nil {
+			t.Fatalf("Failed to write manifest to store: %s", err)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error finishing transaction: %s", err)
+	}
+
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+	result := EvalResult{
+		Txn: txn,
+	}
+
+	err = result.ReadRevisions(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "abc123"
+	if result.Revision != "abc123" {
+		t.Fatalf("Expected revision %v but got %v", expected, result.Revision)
+	}
+
+	if len(result.Revisions) != 0 {
+		t.Fatal("Unexpected multiple bundles")
+	}
+}
+
+func TestReadRevisionsMulti(t *testing.T) {
+	store := inmem.New()
+	ctx := context.Background()
+
+	bundles := map[string]bundle.Manifest{
+		"bundle1": {
+			Revision: "abc123",
+			Roots:    &[]string{"/a/b", "/a/c"},
+		},
+		"bundle2": {
+			Revision: "def123",
+			Roots:    &[]string{"/x/y", "/z"},
+		},
+	}
+
+	// write bundles
+	for name, manifest := range bundles {
+		err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+			err := bundle.WriteManifestToStore(ctx, store, txn, name, manifest)
+			if err != nil {
+				t.Fatalf("Failed to write manifest to store: %s", err)
+			}
+			return err
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error finishing transaction: %s", err)
+		}
+	}
+
+	txn := storage.NewTransactionOrDie(ctx, store, storage.WriteParams)
+
+	result := EvalResult{
+		Txn: txn,
+	}
+
+	err := result.ReadRevisions(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Revisions) != 2 {
+		t.Fatalf("Expected two bundles but got %v", len(result.Revisions))
+	}
+
+	expected := map[string]string{"bundle1": "abc123", "bundle2": "def123"}
+	if !reflect.DeepEqual(result.Revisions, expected) {
+		t.Fatalf("Expected result: %v, got: %v", expected, result.Revisions)
+	}
+
+	if result.Revision != "" {
+		t.Fatalf("Unexpected revision %v", result.Revision)
 	}
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -651,6 +651,10 @@ func (p *envoyExtAuthzGrpcServer) logDecision(ctx context.Context, input interfa
 		info.NDBuiltinCache = &x
 	}
 
+	if err := result.ReadRevisions(ctx, p.Store()); err != nil {
+		return err
+	}
+
 	return decisionlog.LogDecision(ctx, plugin, info, result, err)
 }
 


### PR DESCRIPTION
Bundle Revisions are required if the decision log is enabled. 

**Benchmark results**

Before
```
BenchmarkCheck-12            23270             52283 ns/op           34798 B/op        692 allocs/op
```

After
```
BenchmarkCheck-12            24568             49867 ns/op           34316 B/op        677 allocs/op
```

