### PR TITLE
feat: support query_parameters_to_set in response

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -538,12 +538,21 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 				return nil, stop, internalErr
 			}
 
+			var queryParamsToSet []*ext_core_v3.QueryParameter
+			queryParamsToSet, err = result.GetRequestQueryParametersToSet()
+			if err != nil {
+				err = errors.Wrap(err, "failed to get request query parameters to set")
+				internalErr = newInternalError(EnvoyAuthResultErr, err)
+				return nil, stop, internalErr
+			}
+
 			resp.HttpResponse = &ext_authz_v3.CheckResponse_OkResponse{
 				OkResponse: &ext_authz_v3.OkHttpResponse{
 					Headers:                 responseHeaders,
 					HeadersToRemove:         headersToRemove,
 					ResponseHeadersToAdd:    responseHeadersToAdd,
 					QueryParametersToRemove: queryParamsToRemove,
+					QueryParametersToSet:    queryParamsToSet,
 				},
 			}
 		} else {


### PR DESCRIPTION
Add support for query_parameters_to_set field in response to allow setting/overwriting query parameters before sending upstream. Similar to existing query_parameters_to_remove support.

Example usage in OPA policies:

```rego
package envoy.authz

default allow = true

query_parameters_to_set = {
   "user_id": "123",
   "tenant": "acme"
}

query_parameters_to_set = {
   "role": ["admin", "user"],
   "scope": ["read", "write"]
}

query_parameters_to_set = {
   "user_id": "123",
   "role": ["admin", "user"]
}

result["allowed"] = allow
result["query_parameters_to_set"] = query_parameters_to_set

```