### PR TITLE
fix: build badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opa-envoy-plugin
 
-[![Build Status](https://github.com/open-policy-agent/opa-envoy-plugin/workflows/Post%20Merge/badge.svg?branch=main)](https://github.com/open-policy-agent/opa-envoy-plugin/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/open-policy-agent/opa-envoy-plugin)](https://goreportcard.com/report/github.com/open-policy-agent/opa-envoy-plugin)
+[![Build Status](https://github.com/open-policy-agent/opa-envoy-plugin/actions/workflows/checks.yaml/badge.svg?branch=main)](https://github.com/open-policy-agent/opa-envoy-plugin/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/open-policy-agent/opa-envoy-plugin)](https://goreportcard.com/report/github.com/open-policy-agent/opa-envoy-plugin)
 
 This repository contains an extended version of OPA (**OPA-Envoy**) that allows you to enforce OPA policies with Envoy.
 


### PR DESCRIPTION
Set a valid URL to the Build Badge

Before:
[![Build Status](https://github.com/open-policy-agent/opa-envoy-plugin/workflows/Post%20Merge/badge.svg?branch=main)](https://github.com/open-policy-agent/opa-envoy-plugin/actions)

After:
[![Build Status](https://github.com/open-policy-agent/opa-envoy-plugin/actions/workflows/checks.yaml/badge.svg?branch=main)](https://github.com/open-policy-agent/opa-envoy-plugin/actions)