### PR TITLE
feat: return headers as http.Header

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -282,7 +282,7 @@ func TestCheckAllowWithLogger(t *testing.T) {
 
 	event := customLogger.events[0]
 
-	if event.Error != nil || event.Path != "envoy/authz/allow" ||
+	if event.Error != nil || event.Path != "envoy/authz/result" ||
 		event.Revision != "" || *event.Result == false {
 		t.Fatalf("Unexpected events: %+v", customLogger.events)
 	}
@@ -433,7 +433,7 @@ func TestCheckDenyWithLogger(t *testing.T) {
 
 	event := customLogger.events[0]
 
-	if event.Error != nil || event.Path != "envoy/authz/allow" || event.Revision != "" || *event.Result == true ||
+	if event.Error != nil || event.Path != "envoy/authz/result" || event.Revision != "" || *event.Result == true ||
 		event.DecisionID == "" || event.Metrics == nil {
 		t.Fatal("Unexpected events:", customLogger.events)
 	}
@@ -887,7 +887,7 @@ func TestCheckBadDecisionWithLogger(t *testing.T) {
 
 	event := customLogger.events[0]
 
-	if event.Error == nil || event.Path != "envoy/authz/allow" || event.Revision != "" || event.Result != nil ||
+	if event.Error == nil || event.Path != "envoy/authz/result" || event.Revision != "" || event.Result != nil ||
 		event.DecisionID == "" || event.Metrics == nil {
 		t.Fatalf("Unexpected events: %+v", customLogger.events)
 	}
@@ -1089,7 +1089,7 @@ func TestCheckBadDecisionWithLoggerV2(t *testing.T) {
 
 	event := customLogger.events[0]
 
-	if event.Error == nil || event.Path != "envoy/authz/allow" || event.Revision != "" || event.Result != nil ||
+	if event.Error == nil || event.Path != "envoy/authz/result" || event.Revision != "" || event.Result != nil ||
 		event.DecisionID == "" || event.Metrics == nil {
 		t.Fatalf("Unexpected events: %+v", customLogger.events)
 	}
@@ -1120,7 +1120,7 @@ func TestCheckDenyWithLoggerV2(t *testing.T) {
 
 	event := customLogger.events[0]
 
-	if event.Error != nil || event.Path != "envoy/authz/allow" || event.Revision != "" || *event.Result == true ||
+	if event.Error != nil || event.Path != "envoy/authz/result" || event.Revision != "" || *event.Result == true ||
 		event.DecisionID == "" || event.Metrics == nil {
 		t.Fatal("Unexpected events:", customLogger.events)
 	}
@@ -2100,9 +2100,30 @@ func testAuthzServer(customConfig *Config, customPluginFuncs ...customPluginFunc
 				{"method": "GET",  "path": "/productpage"},
 				{"method": "GET",  "path": "/api/v1/products"},
 			],
+		}
+
+		result.allowed = allow
+
+		result.headers = {
+		  "foo": "bar",
+		  "baz": "qux",
+		}
+
+		result.request_headers_to_remove = ["foo", "bar", "baz", "qux"]
+
+		result.query_parameters_to_remove = ["foo", "bar", "baz", "qux"]
+
+		result.query_parameters_to_set = {
+		  "foo": "bar",
+		  "baz": ["qux", "quux"]
+		}
+
+		result.response_headers_to_add = {
+		  "foo": "bar",
+		  "baz": "qux",
 		}`
 
-	return testAuthzServerWithModule(module, "envoy/authz/allow", customConfig, customPluginFuncs...)
+	return testAuthzServerWithModule(module, "envoy/authz/result", customConfig, customPluginFuncs...)
 }
 
 func testAuthzServerWithModule(module string, path string, customConfig *Config, customPluginFuncs ...customPluginFunc) *envoyExtAuthzGrpcServer {


### PR DESCRIPTION
The PR https://github.com/open-policy-agent/opa-envoy-plugin/pull/628 contains a breaking change. The following function has been removed:
```
func (result *EvalResult) GetResponseHTTPHeaders() (http.Header, error)
```

I would reintroduce it keeping the actual state of logic.

**Benchmark**.

_Before_
```
BenchmarkCheck-12           17308             70453 ns/op           47346 B/op        964 allocs/op
```

_After_
```
BenchmarkCheck-12           17799             69564 ns/op           47317 B/op        960 allocs/op
```