### PR TITLE
docs: Use all interfaces in quick start examples

### DIFF
--- a/examples/envoy-uds/quick_start.yaml
+++ b/examples/envoy-uds/quick_start.yaml
@@ -73,7 +73,7 @@ spec:
             - "run"
             - "--server"
             - "--config-file=/config/config.yaml"
-            - "--addr=localhost:8181"
+            - "--addr=0.0.0.0:8181"
             - "--diagnostic-addr=0.0.0.0:8282"
             - "--ignore=.*"
             - "/policy/policy.rego"

--- a/examples/istio/quick_start.yaml
+++ b/examples/istio/quick_start.yaml
@@ -206,7 +206,7 @@ data:
         "run",
         "--server",
         "--config-file=/config/config.yaml",
-        "--addr=localhost:8181",
+        "--addr=0.0.0.0:8181",
         "--diagnostic-addr=0.0.0.0:8282",
         "/policy/policy.rego",
       ],


### PR DESCRIPTION
The issue is causing some confusion, for example: https://github.com/orgs/open-policy-agent/discussions/671

Related to this work here updating the docs: https://github.com/open-policy-agent/opa/pull/7398