### PR TITLE
Update envoy proxy versions used in tests

### DIFF
--- a/examples/envoy-uds/quick_start.yaml
+++ b/examples/envoy-uds/quick_start.yaml
@@ -38,7 +38,7 @@ spec:
           ports:
             - containerPort: 8080
         - name: envoy
-          image: envoyproxy/envoy:v1.20.0
+          image: envoyproxy/envoy:v1.33-latest
           env:
             - name: ENVOY_UID
               value: "1111"
@@ -170,6 +170,8 @@ data:
                       target_uri: unix:///run/opa/sockets/auth.sock
                     timeout: 0.5s
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
       - name: service
         connect_timeout: 0.25s

--- a/examples/grpc/docker-compose.yaml
+++ b/examples/grpc/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   envoy:
-    image: envoyproxy/envoy:v1.31-latest
+    image: envoyproxy/envoy:v1.33-latest
     ports:
       - "9901:9901"
       - "51051:51051"

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -38,7 +38,7 @@ spec:
           ports:
             - containerPort: 8080
         - name: envoy
-          image: envoyproxy/envoy:v1.10.0
+          image: envoyproxy/envoy:v1.33-latest
           securityContext:
             runAsUser: 1111
           volumeMounts:
@@ -155,8 +155,9 @@ data:
                       target_uri: 127.0.0.1:9191
                       stat_prefix: ext_authz
                     timeout: 0.5s
-              - name: envoy.router
-                typed_config: {}
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
       - name: service
         connect_timeout: 0.25s


### PR DESCRIPTION
Our tests currently use Envoy 1.10 - an _ancient version_ of Envoy. This PR updates the tests to use 1.33 to make sure that we continue to support recent versions of Envoy, as well as to provide users with configuration examples that are pertinent to versions currently in use.