### PR TITLE
chore: adjust stop flow

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -303,8 +303,8 @@ func (p *envoyExtAuthzGrpcServer) Start(ctx context.Context) error {
 }
 
 func (p *envoyExtAuthzGrpcServer) Stop(ctx context.Context) {
-	p.server.GracefulStop()
 	p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateNotReady})
+	p.server.GracefulStop()
 }
 
 func (p *envoyExtAuthzGrpcServer) Reconfigure(ctx context.Context, config interface{}) {


### PR DESCRIPTION
The graceful termination stops accepting new requests and it drains all active connections. The plugin must be already in "unhealthy" status to prevent accepting new requests.