### PR TITLE
Refactor: move interface{} to any

### DIFF
--- a/envoyauth/evaluation.go
+++ b/envoyauth/evaluation.go
@@ -45,7 +45,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 		var txnClose TransactionCloser
 		txn, txnClose, err = result.GetTxn(ctx, evalContext.Store())
 		if err != nil {
-			logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to start new storage transaction.")
+			logger.WithFields(map[string]any{"err": err}).Error("Unable to start new storage transaction.")
 			return err
 		}
 		defer txnClose(ctx, err)
@@ -55,7 +55,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 	result.TxnID = result.Txn.ID()
 
 	if logger.GetLevel() == logging.Debug {
-		logger.WithFields(map[string]interface{}{
+		logger.WithFields(map[string]any{
 			"input": input,
 			"query": evalContext.ParsedQuery().String(),
 			"txn":   result.TxnID,
@@ -79,7 +79,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 		return err
 	}
 
-	ph := hook{logger: logger.WithFields(map[string]interface{}{"decision-id": result.DecisionID})}
+	ph := hook{logger: logger.WithFields(map[string]any{"decision-id": result.DecisionID})}
 
 	var ndbCache builtins.NDBCache
 	if evalContext.Config().NDBuiltinCacheEnabled() {

--- a/envoyauth/evaluation_test.go
+++ b/envoyauth/evaluation_test.go
@@ -39,8 +39,8 @@ func TestEval(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inputValue := ast.MustInterfaceToValue(map[string]interface{}{
-		"parsed_body": map[string]interface{}{
+	inputValue := ast.MustInterfaceToValue(map[string]any{
+		"parsed_body": map[string]any{
 			"firstname": "foo",
 			"lastname":  "bar",
 		},
@@ -249,7 +249,7 @@ func (*testPlugin) Start(context.Context) error {
 func (*testPlugin) Stop(context.Context) {
 }
 
-func (*testPlugin) Reconfigure(context.Context, interface{}) {
+func (*testPlugin) Reconfigure(context.Context, any) {
 }
 
 func (p *testPlugin) Log(_ context.Context, event logs.EventV1) error {

--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -34,9 +34,9 @@ var v3Info = ast.NewObject(
 )
 
 // RequestToInput - Converts a CheckRequest in either protobuf 2 or 3 to an input map
-func RequestToInput(req interface{}, logger logging.Logger, protoSet *protoregistry.Files, skipRequestBodyParse bool) (map[string]interface{}, error) {
+func RequestToInput(req any, logger logging.Logger, protoSet *protoregistry.Files, skipRequestBodyParse bool) (map[string]any, error) {
 	var err error
-	var input map[string]interface{}
+	var input map[string]any
 
 	var rawBody []byte
 	var path, body string
@@ -109,8 +109,8 @@ func getParsedPathAndQuery(path string) ([]string, map[string]any, error) {
 	return parsedPath, parsedQueryInterface, nil
 }
 
-func getParsedBody(logger logging.Logger, headers map[string]string, body string, rawBody []byte, parsedPath []string, protoSet *protoregistry.Files) (interface{}, bool, error) {
-	var data interface{}
+func getParsedBody(logger logging.Logger, headers map[string]string, body string, rawBody []byte, parsedPath []string, protoSet *protoregistry.Files) (any, bool, error) {
+	var data any
 
 	if val, ok := headers["content-type"]; ok {
 		if strings.Contains(val, "application/json") {
@@ -224,7 +224,7 @@ func getParsedBody(logger logging.Logger, headers map[string]string, body string
 				return nil, false, nil
 			}
 
-			values := map[string][]interface{}{}
+			values := map[string][]any{}
 
 			mr := multipart.NewReader(strings.NewReader(payload), boundary)
 			for {
@@ -248,7 +248,7 @@ func getParsedBody(logger logging.Logger, headers map[string]string, body string
 
 				switch {
 				case strings.Contains(p.Header.Get("Content-Type"), "application/json"):
-					var jsonValue interface{}
+					var jsonValue any
 					if err := util.UnmarshalJSON(value, &jsonValue); err != nil {
 						return nil, false, err
 					}
@@ -269,7 +269,7 @@ func getParsedBody(logger logging.Logger, headers map[string]string, body string
 	return data, false, nil
 }
 
-func getGRPCBody(logger logging.Logger, in []byte, parsedPath []string, data interface{}, files *protoregistry.Files) (found, truncated bool, _ error) {
+func getGRPCBody(logger logging.Logger, in []byte, parsedPath []string, data any, files *protoregistry.Files) (found, truncated bool, _ error) {
 
 	// the first 5 bytes are part of gRPC framing. We need to remove them to be able to parse
 	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
@@ -296,12 +296,12 @@ func getGRPCBody(logger logging.Logger, in []byte, parsedPath []string, data int
 	// Note: we've already checked that len(path)>=2
 	svc, err := findService(parsedPath[0], files)
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Debug("could not find service")
+		logger.WithFields(map[string]any{"err": err}).Debug("could not find service")
 		return false, false, nil
 	}
 	msgDesc, err := findMessageInputDesc(parsedPath[1], svc)
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Debug("could not find message")
+		logger.WithFields(map[string]any{"err": err}).Debug("could not find message")
 		return false, false, nil
 	}
 

--- a/envoyauth/request_test.go
+++ b/envoyauth/request_test.go
@@ -291,7 +291,7 @@ func TestGetParsedBody(t *testing.T) {
 		}
 	}`
 	expectedNumber := json.Number("42")
-	expectedObject := map[string]interface{}{
+	expectedObject := map[string]any{
 		"firstname": "foo",
 		"lastname":  "bar",
 	}
@@ -303,25 +303,25 @@ func TestGetParsedBody(t *testing.T) {
 		"firstname": {"foo"},
 		"lastname":  {"bar", "foobar"},
 	}
-	expectedArray := []interface{}{"hello", "opa"}
-	expectedJSONSpecialChars := []interface{}{`"`, `\`, "/", "/", "\b", "\f", "\n", "\r", "\t", "A"}
-	expectedMultipartFormData := map[string][]interface{}{
+	expectedArray := []any{"hello", "opa"}
+	expectedJSONSpecialChars := []any{`"`, `\`, "/", "/", "\b", "\f", "\n", "\r", "\t", "A"}
+	expectedMultipartFormData := map[string][]any{
 		"foo": {"bar"},
 	}
-	expectedMultipartFormDataWithJSON := map[string][]interface{}{
+	expectedMultipartFormDataWithJSON := map[string][]any{
 		"foo": {"bar"},
 		"bar": {
-			map[string]interface{}{"name": "bar"},
+			map[string]any{"name": "bar"},
 		},
 	}
-	expectedContentTypeJSONRawBody := map[string]interface{}{
+	expectedContentTypeJSONRawBody := map[string]any{
 		"firstname": "foo",
 		"lastname":  "bar",
 	}
 
 	tests := map[string]struct {
 		input           *ext_authz.CheckRequest
-		want            interface{}
+		want            any
 		isBodyTruncated bool
 		err             error
 	}{
@@ -552,17 +552,17 @@ func TestGetParsedBodygRPC(t *testing.T) {
 }
 `
 
-	expectedObject := map[string]interface{}{
-		"Data": map[string]interface{}{
+	expectedObject := map[string]any{
+		"Data": map[string]any{
 			"Body": "Body value",
 			"Name": "Name Value",
 		},
-		"Metadata": map[string]interface{}{
+		"Metadata": map[string]any{
 			"SeverityNumber": "SecNumber",
 			"SeverityText":   "ERROR",
 		},
 	}
-	expectedObjectExampleBook := map[string]interface{}{"author": "John"}
+	expectedObjectExampleBook := map[string]any{"author": "John"}
 	protoDescriptorPath := "../test/files/combined.pb"
 	protoSet, err := internal_util.ReadProtoSet(protoDescriptorPath)
 	if err != nil {
@@ -571,7 +571,7 @@ func TestGetParsedBodygRPC(t *testing.T) {
 
 	tests := map[string]struct {
 		input           *ext_authz.CheckRequest
-		want            interface{}
+		want            any
 		isBodyTruncated bool
 		err             error
 	}{
@@ -581,7 +581,7 @@ func TestGetParsedBodygRPC(t *testing.T) {
 		"valid_parsed_book":    {input: createCheckRequest(requestValidBook), want: expectedObjectExampleBook, isBodyTruncated: false, err: nil},
 		"unknown_service":      {input: createCheckRequest(requestUnknownService), want: nil, isBodyTruncated: false, err: nil},
 		"unknown_method":       {input: createCheckRequest(requestUnknownMethod), want: nil, isBodyTruncated: false, err: nil},
-		"empty_request":        {input: createCheckRequest(requestEmpty), want: map[string]interface{}{}, isBodyTruncated: false, err: nil},
+		"empty_request":        {input: createCheckRequest(requestEmpty), want: map[string]any{}, isBodyTruncated: false, err: nil},
 		"compressed_payload":   {input: createCheckRequest(requestCompressedPayload), want: nil, isBodyTruncated: false, err: nil},
 		"truncated_payload":    {input: createCheckRequest(requestTruncatedPayload), want: nil, isBodyTruncated: true, err: nil},
 	}
@@ -618,37 +618,37 @@ func TestParsedPathAndQuery(t *testing.T) {
 	var tests = []struct {
 		request       *ext_authz.CheckRequest
 		expectedPath  []string
-		expectedQuery map[string]interface{}
+		expectedQuery map[string]any
 	}{
 		{
 			createExtReqWithPath("/my/test/path"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{},
+			map[string]any{},
 		},
 		{
 			createExtReqWithPath("/my/test/path?a=1"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{"a": []string{"1"}},
+			map[string]any{"a": []string{"1"}},
 		},
 		{
 			createExtReqWithPath("/my/test/path?a=1&a=2"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{"a": []string{"1", "2"}},
+			map[string]any{"a": []string{"1", "2"}},
 		},
 		{
 			createExtReqWithPath("/my/test/path?a=1&b=2"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{"a": []string{"1"}, "b": []string{"2"}},
+			map[string]any{"a": []string{"1"}, "b": []string{"2"}},
 		},
 		{
 			createExtReqWithPath("/my/test/path?a=1&a=new%0aline"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{"a": []string{"1", "new\nline"}},
+			map[string]any{"a": []string{"1", "new\nline"}},
 		},
 		{
 			createExtReqWithPath("%2Fmy%2Ftest%2Fpath?a=1&a=new%0aline"),
 			[]string{"my", "test", "path"},
-			map[string]interface{}{"a": []string{"1", "new\nline"}},
+			map[string]any{"a": []string{"1", "new\nline"}},
 		},
 	}
 

--- a/envoyauth/response_test.go
+++ b/envoyauth/response_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestIsAllowed(t *testing.T) {
 
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -150,7 +150,7 @@ func TestReadRevisionsMulti(t *testing.T) {
 
 func TestGetRequestQueryParametersToRemove(t *testing.T) {
 	tests := map[string]struct {
-		decision interface{}
+		decision any
 		exp      []string
 		wantErr  bool
 	}{
@@ -165,27 +165,27 @@ func TestGetRequestQueryParametersToRemove(t *testing.T) {
 			true,
 		},
 		"empty_map_result": {
-			map[string]interface{}{},
+			map[string]any{},
 			nil,
 			false,
 		},
 		"bad_param_value": {
-			map[string]interface{}{"query_parameters_to_remove": "test"},
+			map[string]any{"query_parameters_to_remove": "test"},
 			nil,
 			true,
 		},
 		"string_array_param_value": {
-			map[string]interface{}{"query_parameters_to_remove": []string{"foo", "bar"}},
+			map[string]any{"query_parameters_to_remove": []string{"foo", "bar"}},
 			[]string{"foo", "bar"},
 			false,
 		},
 		"interface_array_param_value": {
-			map[string]interface{}{"query_parameters_to_remove": []interface{}{"foo", "bar", "fuz"}},
+			map[string]any{"query_parameters_to_remove": []any{"foo", "bar", "fuz"}},
 			[]string{"foo", "bar", "fuz"},
 			false,
 		},
 		"interface_array_bad_param_value": {
-			map[string]interface{}{"query_parameters_to_remove": []interface{}{1}},
+			map[string]any{"query_parameters_to_remove": []any{1}},
 			nil,
 			true,
 		},
@@ -218,7 +218,7 @@ func TestGetRequestQueryParametersToRemove(t *testing.T) {
 
 func TestGetQueryParametersToSet(t *testing.T) {
 	tests := map[string]struct {
-		decision interface{}
+		decision any
 		exp      []*ext_core_v3.QueryParameter
 		wantErr  bool
 	}{
@@ -228,20 +228,20 @@ func TestGetQueryParametersToSet(t *testing.T) {
 			false,
 		},
 		"empty_map_result": {
-			map[string]interface{}{},
+			map[string]any{},
 			nil,
 			false,
 		},
 		"invalid_type": {
-			map[string]interface{}{
+			map[string]any{
 				"query_parameters_to_set": "invalid",
 			},
 			nil,
 			true,
 		},
 		"invalid_value_type": {
-			map[string]interface{}{
-				"query_parameters_to_set": map[string]interface{}{
+			map[string]any{
+				"query_parameters_to_set": map[string]any{
 					"test": 123,
 				},
 			},
@@ -249,17 +249,17 @@ func TestGetQueryParametersToSet(t *testing.T) {
 			true,
 		},
 		"invalid_array_value_type": {
-			map[string]interface{}{
-				"query_parameters_to_set": map[string]interface{}{
-					"test": []interface{}{123},
+			map[string]any{
+				"query_parameters_to_set": map[string]any{
+					"test": []any{123},
 				},
 			},
 			nil,
 			true,
 		},
 		"single_value": {
-			map[string]interface{}{
-				"query_parameters_to_set": map[string]interface{}{
+			map[string]any{
+				"query_parameters_to_set": map[string]any{
 					"param1": "value1",
 					"param2": "value2",
 				},
@@ -277,10 +277,10 @@ func TestGetQueryParametersToSet(t *testing.T) {
 			false,
 		},
 		"array_values": {
-			map[string]interface{}{
-				"query_parameters_to_set": map[string]interface{}{
-					"param1": []interface{}{"value1", "value2"},
-					"param2": []interface{}{"value3", "value4"},
+			map[string]any{
+				"query_parameters_to_set": map[string]any{
+					"param1": []any{"value1", "value2"},
+					"param2": []any{"value3", "value4"},
 				},
 			},
 			[]*ext_core_v3.QueryParameter{
@@ -304,10 +304,10 @@ func TestGetQueryParametersToSet(t *testing.T) {
 			false,
 		},
 		"mixed_values": {
-			map[string]interface{}{
-				"query_parameters_to_set": map[string]interface{}{
+			map[string]any{
+				"query_parameters_to_set": map[string]any{
 					"param1": "single",
-					"param2": []interface{}{"multi1", "multi2"},
+					"param2": []any{"multi1", "multi2"},
 				},
 			},
 			[]*ext_core_v3.QueryParameter{
@@ -377,7 +377,7 @@ func TestGetQueryParametersToSet(t *testing.T) {
 
 func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 	tests := map[string]struct {
-		decision interface{}
+		decision any
 		exp      []string
 		wantErr  bool
 	}{
@@ -392,27 +392,27 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 			true,
 		},
 		"empty_map_result": {
-			map[string]interface{}{},
+			map[string]any{},
 			nil,
 			false,
 		},
 		"bad_header_value": {
-			map[string]interface{}{"request_headers_to_remove": "test"},
+			map[string]any{"request_headers_to_remove": "test"},
 			nil,
 			true,
 		},
 		"string_array_header_value": {
-			map[string]interface{}{"request_headers_to_remove": []string{"foo", "bar"}},
+			map[string]any{"request_headers_to_remove": []string{"foo", "bar"}},
 			[]string{"foo", "bar"},
 			false,
 		},
 		"interface_array_header_value": {
-			map[string]interface{}{"request_headers_to_remove": []interface{}{"foo", "bar", "fuz"}},
+			map[string]any{"request_headers_to_remove": []any{"foo", "bar", "fuz"}},
 			[]string{"foo", "bar", "fuz"},
 			false,
 		},
 		"interface_array_bad_header_value": {
-			map[string]interface{}{"request_headers_to_remove": []interface{}{1}},
+			map[string]any{"request_headers_to_remove": []any{1}},
 			nil,
 			true,
 		},
@@ -444,7 +444,7 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 
 	t.Run("type_assertion_error", func(t *testing.T) {
 		er := EvalResult{
-			Decision: map[string]interface{}{"request_headers_to_remove": 1},
+			Decision: map[string]any{"request_headers_to_remove": 1},
 		}
 
 		_, err := er.GetRequestHTTPHeadersToRemove()
@@ -459,7 +459,7 @@ func TestGetRequestHTTPHeadersToRemove(t *testing.T) {
 }
 
 func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -481,7 +481,7 @@ func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	testHeaders := make(map[string]interface{})
+	testHeaders := make(map[string]any)
 	testHeaders["foo"] = "bar"
 	input["response_headers_to_add"] = testHeaders
 
@@ -501,11 +501,11 @@ func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	input["response_headers_to_add"] = []interface{}{
-		map[string]interface{}{
+	input["response_headers_to_add"] = []any{
+		map[string]any{
 			"foo": "bar",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"foo": "baz",
 		},
 	}
@@ -519,7 +519,7 @@ func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
 		t.Fatalf("Expected two headers but got %v", len(result))
 	}
 
-	testAddHeaders := make(map[string]interface{})
+	testAddHeaders := make(map[string]any)
 	testAddHeaders["foo"] = []string{"bar", "baz"}
 	input["response_headers_to_add"] = testAddHeaders
 
@@ -535,7 +535,7 @@ func TestGetResponseHTTPHeadersToAdd(t *testing.T) {
 }
 
 func TestGetResponseHeaderValueOptions(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -557,7 +557,7 @@ func TestGetResponseHeaderValueOptions(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	testHeaders := make(map[string]interface{})
+	testHeaders := make(map[string]any)
 	testHeaders["foo"] = "bar"
 	input["headers"] = testHeaders
 
@@ -577,11 +577,11 @@ func TestGetResponseHeaderValueOptions(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	input["headers"] = []interface{}{
-		map[string]interface{}{
+	input["headers"] = []any{
+		map[string]any{
 			"foo": "bar",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"foo": "baz",
 		},
 	}
@@ -603,7 +603,7 @@ func TestGetResponseHeaderValueOptions(t *testing.T) {
 		t.Errorf("expected 'bar' and 'baz', got %v", seen)
 	}
 
-	testAddHeaders := make(map[string]interface{})
+	testAddHeaders := make(map[string]any)
 	testAddHeaders["foo"] = []string{"bar", "baz"}
 	input["headers"] = testAddHeaders
 
@@ -617,7 +617,7 @@ func TestGetResponseHeaderValueOptions(t *testing.T) {
 		t.Fatalf("Expected two header but got %v", len(result))
 	}
 
-	testAddHeaders["foo"] = []interface{}{"bar", "baz"}
+	testAddHeaders["foo"] = []any{"bar", "baz"}
 	input["headers"] = testAddHeaders
 
 	result, err = er.GetResponseEnvoyHeaderValueOptions()
@@ -636,7 +636,7 @@ func TestGetResponseHeaderValueOptions(t *testing.T) {
 }
 
 func TestGetResponseHeaders(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -658,7 +658,7 @@ func TestGetResponseHeaders(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	testHeaders := make(map[string]interface{})
+	testHeaders := make(map[string]any)
 	testHeaders["foo"] = "bar"
 	input["headers"] = testHeaders
 
@@ -678,11 +678,11 @@ func TestGetResponseHeaders(t *testing.T) {
 		t.Fatal("Expected error but got nil")
 	}
 
-	input["headers"] = []interface{}{
-		map[string]interface{}{
+	input["headers"] = []any{
+		map[string]any{
 			"foo": "bar",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"foo": "baz",
 		},
 	}
@@ -707,7 +707,7 @@ func TestGetResponseHeaders(t *testing.T) {
 		t.Errorf("expected 'bar' and 'baz', got %v", seen)
 	}
 
-	testAddHeaders := make(map[string]interface{})
+	testAddHeaders := make(map[string]any)
 	testAddHeaders["foo"] = []string{"bar", "baz"}
 	input["headers"] = testAddHeaders
 
@@ -721,7 +721,7 @@ func TestGetResponseHeaders(t *testing.T) {
 		t.Fatalf("Expected two header but got %v", len(result.Values("foo")))
 	}
 
-	testAddHeaders["foo"] = []interface{}{"bar", "baz"}
+	testAddHeaders["foo"] = []any{"bar", "baz"}
 	input["headers"] = testAddHeaders
 
 	result, err = er.GetResponseHTTPHeaders()
@@ -740,7 +740,7 @@ func TestGetResponseHeaders(t *testing.T) {
 }
 
 func TestGetResponseBody(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -776,7 +776,7 @@ func TestGetResponseBody(t *testing.T) {
 }
 
 func TestGetResponseHttpStatus(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -824,7 +824,7 @@ func TestGetResponseHttpStatus(t *testing.T) {
 }
 
 func TestGetDynamicMetadata(t *testing.T) {
-	input := make(map[string]interface{})
+	input := make(map[string]any)
 	er := EvalResult{
 		Decision: input,
 	}
@@ -838,7 +838,7 @@ func TestGetDynamicMetadata(t *testing.T) {
 		t.Fatalf("Expected no dynamic metadata but got %v", result)
 	}
 
-	input["dynamic_metadata"] = map[string]interface{}{
+	input["dynamic_metadata"] = map[string]any{
 		"foo": "bar",
 	}
 	result, err = er.GetDynamicMetadata()

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -307,7 +307,7 @@ func (p *envoyExtAuthzGrpcServer) Stop(ctx context.Context) {
 	p.server.GracefulStop()
 }
 
-func (p *envoyExtAuthzGrpcServer) Reconfigure(ctx context.Context, config interface{}) {
+func (p *envoyExtAuthzGrpcServer) Reconfigure(ctx context.Context, config any) {
 	return
 }
 
@@ -324,7 +324,7 @@ func (p *envoyExtAuthzGrpcServer) listen() {
 
 	parsedURL, err := url.Parse(addr)
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to parse url.")
+		logger.WithFields(map[string]any{"err": err}).Error("Unable to parse url.")
 		return
 	}
 
@@ -349,11 +349,11 @@ func (p *envoyExtAuthzGrpcServer) listen() {
 	}
 
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to create listener.")
+		logger.WithFields(map[string]any{"err": err}).Error("Unable to create listener.")
 		return
 	}
 
-	logger.WithFields(map[string]interface{}{
+	logger.WithFields(map[string]any{
 		"addr":              p.cfg.Addr,
 		"query":             p.cfg.Query,
 		"path":              p.cfg.Path,
@@ -364,7 +364,7 @@ func (p *envoyExtAuthzGrpcServer) listen() {
 	p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateOK})
 
 	if err := p.server.Serve(l); err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Error("Listener failed.")
+		logger.WithFields(map[string]any{"err": err}).Error("Listener failed.")
 		return
 	}
 
@@ -385,7 +385,7 @@ func (p *envoyExtAuthzGrpcServer) Check(ctx context.Context, req *ext_authz_v3.C
 	return resp, nil
 }
 
-func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*ext_authz_v3.CheckResponse, func() *rpc_status.Status, *Error) {
+func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req any) (*ext_authz_v3.CheckResponse, func() *rpc_status.Status, *Error) {
 	var err error
 	var evalErr error
 	var internalErr *Error
@@ -394,23 +394,23 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 
 	result, stopeval, err := envoyauth.NewEvalResult()
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to start new evaluation.")
+		logger.WithFields(map[string]any{"err": err}).Error("Unable to start new evaluation.")
 		internalErr = newInternalError(StartCheckErr, err)
 		return nil, func() *rpc_status.Status { return nil }, internalErr
 	}
 
 	txn, txnClose, err := result.GetTxn(ctx, p.Store())
 	if err != nil {
-		logger.WithFields(map[string]interface{}{"err": err}).Error("Unable to start new storage transaction.")
+		logger.WithFields(map[string]any{"err": err}).Error("Unable to start new storage transaction.")
 		internalErr = newInternalError(StartTxnErr, err)
 		return nil, func() *rpc_status.Status { return nil }, internalErr
 	}
 
 	result.Txn = txn
 
-	logger = logger.WithFields(map[string]interface{}{"decision-id": result.DecisionID})
+	logger = logger.WithFields(map[string]any{"decision-id": result.DecisionID})
 
-	var input map[string]interface{}
+	var input map[string]any
 
 	stop := func() *rpc_status.Status {
 		stopeval()
@@ -425,7 +425,7 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 		logErr := p.logDecision(ctx, input, result, err)
 		if logErr != nil {
 			_ = txnClose(ctx, logErr) // Ignore error
-			logger.WithFields(map[string]interface{}{"err": logErr}).Debug("Error when logging event")
+			logger.WithFields(map[string]any{"err": logErr}).Debug("Error when logging event")
 			if p.cfg.EnablePerformanceMetrics {
 				p.metricErrorCounter.With(prometheus.Labels{"reason": "unknown_log_error"}).Inc()
 			}
@@ -494,7 +494,7 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 	resp.Status = &rpc_status.Status{Code: status}
 
 	switch result.Decision.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		var responseHeaders []*ext_core_v3.HeaderValueOption
 		responseHeaders, err = result.GetResponseEnvoyHeaderValueOptions()
 		if err != nil {
@@ -593,7 +593,7 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 	}
 
 	if logger.GetLevel() == logging.Debug {
-		logger.WithFields(map[string]interface{}{
+		logger.WithFields(map[string]any{
 			"query":               p.cfg.parsedQuery.String(),
 			"dry-run":             p.cfg.DryRun,
 			"decision":            result.Decision,
@@ -627,7 +627,7 @@ func (p *envoyExtAuthzGrpcServer) check(ctx context.Context, req interface{}) (*
 	return resp, stop, nil
 }
 
-func (p *envoyExtAuthzGrpcServer) logDecision(ctx context.Context, input interface{}, result *envoyauth.EvalResult, err error) error {
+func (p *envoyExtAuthzGrpcServer) logDecision(ctx context.Context, input any, result *envoyauth.EvalResult, err error) error {
 	plugin := logs.Lookup(p.manager)
 	if plugin == nil {
 		return nil

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -498,7 +498,7 @@ func TestCheckAllowWithLoggerNDBCache(t *testing.T) {
 	}
 
 	cache := *event.NDBuiltinCache
-	nd, ok := cache.(map[string]interface{})
+	nd, ok := cache.(map[string]any)
 	if !ok {
 		t.Errorf("bad type assertion")
 	}
@@ -548,7 +548,7 @@ func TestCheckContextTimeout(t *testing.T) {
 		t.Fatalf("Expected error message %v but got %v", expectedErrMsg, event.Error.Error())
 	}
 
-	if len((*event.Input).(map[string]interface{})) == 0 {
+	if len((*event.Input).(map[string]any)) == 0 {
 		t.Fatalf("Expected non empty input but got %v", *event.Input)
 	}
 
@@ -594,7 +594,7 @@ func TestCheckContextTimeoutMetricsDisabled(t *testing.T) {
 		t.Fatalf("Expected error message %v but got %v", expectedErrMsg, event.Error.Error())
 	}
 
-	if len((*event.Input).(map[string]interface{})) == 0 {
+	if len((*event.Input).(map[string]any)) == 0 {
 		t.Fatalf("Expected non empty input but got %v", *event.Input)
 	}
 }
@@ -694,7 +694,7 @@ func TestCheckDenyDecisionTruncatedBodyWithLogger(t *testing.T) {
 	}
 
 	input := *event.Input
-	inputMap, _ := input.(map[string]interface{})
+	inputMap, _ := input.(map[string]any)
 	isTruncated, _ := inputMap["truncated_body"].(bool)
 
 	if !isTruncated {
@@ -734,7 +734,7 @@ func TestCheckAllowDecisionWithSkipRequestBodyParse(t *testing.T) {
 	}
 
 	input := *event.Input
-	inputMap, _ := input.(map[string]interface{})
+	inputMap, _ := input.(map[string]any)
 
 	if _, ok := inputMap["truncated_body"]; ok {
 		t.Fatal("Unexpected key \"truncated_body\" in input")
@@ -810,7 +810,7 @@ func TestCheckDecisionTruncatedBodyWithLogger(t *testing.T) {
 	}
 
 	input := *event.Input
-	inputMap, _ := input.(map[string]interface{})
+	inputMap, _ := input.(map[string]any)
 	isTruncated, _ := inputMap["truncated_body"].(bool)
 
 	if !isTruncated {
@@ -844,7 +844,7 @@ func TestCheckDecisionTruncatedBodyWithLogger(t *testing.T) {
 	}
 
 	input = *event.Input
-	inputMap, _ = input.(map[string]interface{})
+	inputMap, _ = input.(map[string]any)
 	isTruncated, _ = inputMap["truncated_body"].(bool)
 
 	if isTruncated {
@@ -2471,7 +2471,7 @@ func (p *testPlugin) Start(context.Context) error {
 func (p *testPlugin) Stop(context.Context) {
 }
 
-func (p *testPlugin) Reconfigure(context.Context, interface{}) {
+func (p *testPlugin) Reconfigure(context.Context, any) {
 }
 
 func (p *testPlugin) Log(_ context.Context, event logs.EventV1) error {
@@ -2490,7 +2490,7 @@ func (p *testPluginError) Start(context.Context) error {
 func (p *testPluginError) Stop(context.Context) {
 }
 
-func (p *testPluginError) Reconfigure(context.Context, interface{}) {
+func (p *testPluginError) Reconfigure(context.Context, any) {
 }
 
 func (p *testPluginError) Log(_ context.Context, event logs.EventV1) error {

--- a/opa/decisionlog/decision_log.go
+++ b/opa/decisionlog/decision_log.go
@@ -50,7 +50,7 @@ func LogDecision(ctx context.Context, plugin *logs.Plugin, info *server.Info, re
 		}
 		info.Error = err
 	} else {
-		var x interface{}
+		var x any
 		if result != nil {
 			x = result.Decision
 		}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -17,11 +17,11 @@ type Factory struct{}
 const PluginName = internal.PluginName
 
 // New returns the object initialized with a valid plugin configuration.
-func (Factory) New(m *plugins.Manager, config interface{}) plugins.Plugin {
+func (Factory) New(m *plugins.Manager, config any) plugins.Plugin {
 	return internal.New(m, config.(*internal.Config))
 }
 
 // Validate returns a valid configuration to instantiate the plugin.
-func (Factory) Validate(m *plugins.Manager, config []byte) (interface{}, error) {
+func (Factory) Validate(m *plugins.Manager, config []byte) (any, error) {
 	return internal.Validate(m, config)
 }

--- a/test/e2e/testing.go
+++ b/test/e2e/testing.go
@@ -24,7 +24,7 @@ func (*testPlugin) Start(context.Context) error {
 func (*testPlugin) Stop(context.Context) {
 }
 
-func (*testPlugin) Reconfigure(context.Context, interface{}) {
+func (*testPlugin) Reconfigure(context.Context, any) {
 }
 
 func (p *testPlugin) Log(_ context.Context, event logs.EventV1) error {


### PR DESCRIPTION
Golang has supported the `any` alias for the `interface{}` type since Go 1.18. `any` enhances the legibility of code and makes it easier to parse, particularly in complex type assertions, which we have many of in this project.