### PR TITLE
Fixing broken link to OPA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use this version of OPA to enforce fine-grained, context-aware access
 control policies with Envoy _without_ modifying your microservice.
 
 More information about the OPA-Envoy plugin including performance benchmarks, debugging tips, detailed usage examples
-can be found in the [OPA documentation](https://www.openpolicyagent.org/docs/edge/envoy).
+can be found in the [OPA documentation](https://www.openpolicyagent.org/docs/envoy).
 
 ## Quick Start
 

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -20,7 +20,7 @@ availability) in order to perform the authorization check.
 
 ## Quick Start
 
-Follow the tutorial described [here](https://www.openpolicyagent.org/docs/latest/envoy-tutorial-istio/).
+Follow the tutorial described [here](https://www.openpolicyagent.org/docs/envoy/tutorial-istio/).
 
 ## Controlling the injection policy at the pod level
 


### PR DESCRIPTION
Updates to the OPA docs website has left `https://www.openpolicyagent.org/docs/edge` URL:s broken. 