### PR TITLE
reenable govet linter and fix its violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -195,7 +195,7 @@ linters:
   enable:
     - mirror
     # - errcheck # reenable after https://github.com/open-policy-agent/opa-envoy-plugin/issues/723 is complete
-    # - govet # reenable after https://github.com/open-policy-agent/opa-envoy-plugin/issues/727 is complete
+    - govet
     - ineffassign
     - intrange
     # - revive # replacement for golint # reenable after https://github.com/open-policy-agent/opa-envoy-plugin/issues/724 is complete

--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -3,6 +3,7 @@ package envoyauth
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -32,6 +33,7 @@ var v3Info = ast.NewObject(
 	keyValue("ext_authz", "v3"),
 	keyValue("encoding", "protojson"),
 )
+var errInvalidPath = errors.New("invalid parsed path")
 
 // RequestToInput - Converts a CheckRequest in either protobuf 2 or 3 to an input map
 func RequestToInput(req any, logger logging.Logger, protoSet *protoregistry.Files, skipRequestBodyParse bool) (map[string]any, error) {
@@ -153,7 +155,7 @@ func getParsedBody(logger logging.Logger, headers map[string]string, body string
 			// POST to /ThingService/DoThing. If our path length is anything but
 			// two, something is wrong.
 			if len(parsedPath) != 2 {
-				return nil, false, fmt.Errorf("invalid parsed path")
+				return nil, false, errInvalidPath
 			}
 
 			known, truncated, err := getGRPCBody(logger, rawBody, parsedPath, &data, protoSet)

--- a/envoyauth/request_test.go
+++ b/envoyauth/request_test.go
@@ -2,6 +2,7 @@ package envoyauth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -363,7 +364,7 @@ func TestGetParsedBody(t *testing.T) {
 				t.Fatalf("expected isBodyTruncated: %v, got: %v", tc.isBodyTruncated, got)
 			}
 
-			if err != tc.err {
+			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected error: %v, got: %v", tc.err, err)
 			}
 		})
@@ -575,7 +576,7 @@ func TestGetParsedBodygRPC(t *testing.T) {
 		isBodyTruncated bool
 		err             error
 	}{
-		"parsed_path_error":    {input: createCheckRequest(requestInvalidParsedPathExample), want: nil, isBodyTruncated: false, err: fmt.Errorf("invalid parsed path")},
+		"parsed_path_error":    {input: createCheckRequest(requestInvalidParsedPathExample), want: nil, isBodyTruncated: false, err: errInvalidPath},
 		"without_raw_body":     {input: createCheckRequest(requestInvalidRawBodyExample), want: nil, isBodyTruncated: false, err: nil},
 		"valid_parsed_example": {input: createCheckRequest(requestValidExample), want: expectedObject, isBodyTruncated: false, err: nil},
 		"valid_parsed_book":    {input: createCheckRequest(requestValidBook), want: expectedObjectExampleBook, isBodyTruncated: false, err: nil},
@@ -598,7 +599,7 @@ func TestGetParsedBodygRPC(t *testing.T) {
 			parsedPath, _, _ := getParsedPathAndQuery(path)
 			got, isBodyTruncated, err := getParsedBody(logger, headers, body, rawBody, parsedPath, protoSet)
 
-			if !reflect.DeepEqual(err, tc.err) {
+			if !errors.Is(err, tc.err) {
 				t.Fatalf("expected error: %v, got: %v", tc.err, err)
 			}
 

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -199,7 +199,7 @@ func TestCheckTrigger(t *testing.T) {
 		t.Fatal("Expected request to be allowed but got:", output)
 	}
 
-	if !reflect.DeepEqual(originalPreparedQuery, server.preparedQuery) {
+	if originalPreparedQuery != server.preparedQuery {
 		t.Fatal("Expected same instance of prepared query")
 	}
 
@@ -215,7 +215,7 @@ func TestCheckTrigger(t *testing.T) {
 		t.Fatal("Expected request to be allowed but got:", output)
 	}
 
-	if reflect.DeepEqual(originalPreparedQuery, server.preparedQuery) {
+	if originalPreparedQuery == server.preparedQuery {
 		t.Fatal("Expected different instance of prepared query")
 	}
 }


### PR DESCRIPTION
- Replace `err != tc.err` with `errors.Is(err, tc.err)` in envoyauth/request_test.go
- Swap `reflect.DeepEqual` for `==` in internal/internal_test.go
- Use package-level variable ErrInvalidPath for consistent errors.Is() checks

Resolves #727 