### PR TITLE
reenable revive linter and fix its violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -198,7 +198,7 @@ linters:
     - govet
     - ineffassign
     - intrange
-    # - revive # replacement for golint # reenable after https://github.com/open-policy-agent/opa-envoy-plugin/issues/724 is complete
+    - revive
     - gofmt
     - goimports
     - unused

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -307,7 +307,7 @@ func (p *envoyExtAuthzGrpcServer) Stop(ctx context.Context) {
 	p.server.GracefulStop()
 }
 
-func (p *envoyExtAuthzGrpcServer) Reconfigure(ctx context.Context, config any) {
+func (_ *envoyExtAuthzGrpcServer) Reconfigure(ctx context.Context, config any) {
 	return
 }
 

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -2464,14 +2464,14 @@ type testPlugin struct {
 	events []logs.EventV1
 }
 
-func (p *testPlugin) Start(context.Context) error {
+func (_ *testPlugin) Start(context.Context) error {
 	return nil
 }
 
-func (p *testPlugin) Stop(context.Context) {
+func (_ *testPlugin) Stop(context.Context) {
 }
 
-func (p *testPlugin) Reconfigure(context.Context, any) {
+func (_ *testPlugin) Reconfigure(context.Context, any) {
 }
 
 func (p *testPlugin) Log(_ context.Context, event logs.EventV1) error {
@@ -2483,14 +2483,14 @@ type testPluginError struct {
 	events []logs.EventV1
 }
 
-func (p *testPluginError) Start(context.Context) error {
+func (_ *testPluginError) Start(context.Context) error {
 	return nil
 }
 
-func (p *testPluginError) Stop(context.Context) {
+func (_ *testPluginError) Stop(context.Context) {
 }
 
-func (p *testPluginError) Reconfigure(context.Context, any) {
+func (_ *testPluginError) Reconfigure(context.Context, any) {
 }
 
 func (p *testPluginError) Log(_ context.Context, event logs.EventV1) error {


### PR DESCRIPTION
refactor: use blank identifier for unused method receivers.

Resolves #724  :)