### PR TITLE
reenable perfsprint linter and fix its violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -210,6 +210,6 @@ linters:
     - prealloc
     - unconvert
     - copyloopvar
-    # - perfsprint # reenable after https://github.com/open-policy-agent/opa-envoy-plugin/issues/729 is complete
+    - perfsprint
     - gocritic
     # - gosec # too many false positives

--- a/envoyauth/evaluation.go
+++ b/envoyauth/evaluation.go
@@ -2,7 +2,7 @@ package envoyauth
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/config"
@@ -110,9 +110,9 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 	case err != nil:
 		return err
 	case len(rs) == 0:
-		return fmt.Errorf("undefined decision")
+		return errors.New("undefined decision")
 	case len(rs) > 1:
-		return fmt.Errorf("multiple evaluation results")
+		return errors.New("multiple evaluation results")
 	}
 
 	result.NDBuiltinCache = ndbCache

--- a/envoyauth/request.go
+++ b/envoyauth/request.go
@@ -294,7 +294,7 @@ func getGRPCBody(logger logging.Logger, in []byte, parsedPath []string, data any
 	// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 
 	if len(in) < 5 {
-		return false, false, fmt.Errorf("less than 5 bytes")
+		return false, false, errors.New("less than 5 bytes")
 	}
 
 	// Can be 0 or 1, 1 indicates that the payload is compressed.

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -3,6 +3,7 @@ package envoyauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -127,7 +128,7 @@ func (result *EvalResult) IsAllowed() (bool, error) {
 		var ok, allowed bool
 
 		if val, ok = decision["allowed"]; !ok {
-			return false, fmt.Errorf("unable to determine evaluation result due to missing \"allowed\" key")
+			return false, errors.New("unable to determine evaluation result due to missing \"allowed\" key")
 		}
 
 		if allowed, ok = val.(bool); !ok {
@@ -299,7 +300,7 @@ func (result *EvalResult) GetResponseHTTPStatus() (int, error) {
 	switch decision := result.Decision.(type) {
 	case bool:
 		if decision {
-			return http.StatusOK, fmt.Errorf("HTTP status code undefined for simple 'allow'")
+			return http.StatusOK, errors.New("HTTP status code undefined for simple 'allow'")
 		}
 
 		return status, nil
@@ -332,7 +333,7 @@ func (result *EvalResult) GetDynamicMetadata() (*_structpb.Struct, error) {
 	switch decision := result.Decision.(type) {
 	case bool:
 		if decision {
-			return nil, fmt.Errorf("dynamic metadata undefined for boolean decision")
+			return nil, errors.New("dynamic metadata undefined for boolean decision")
 		}
 	case map[string]any:
 		var (

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -108,7 +108,7 @@ func Validate(m *plugins.Manager, bs []byte) (*Config, error) {
 	}
 
 	if cfg.Path != "" && cfg.Query != "" {
-		return nil, fmt.Errorf("invalid config: specify a value for only the \"path\" field")
+		return nil, errors.New("invalid config: specify a value for only the \"path\" field")
 	}
 
 	var parsedQuery ast.Body

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -2583,5 +2583,5 @@ func (_ *testPluginError) Reconfigure(context.Context, any) {
 
 func (p *testPluginError) Log(_ context.Context, event logs.EventV1) error {
 	p.events = append(p.events, event)
-	return fmt.Errorf("Bad Logger Error")
+	return errors.New("Bad Logger Error")
 }


### PR DESCRIPTION
Enable `perfsprint` linter and switch to errors.New for static error messages

resolves #729 