### PR TITLE
Passthrough metadata labels for logs

### DIFF
--- a/envoyauth/evaluation.go
+++ b/envoyauth/evaluation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 	iCache "github.com/open-policy-agent/opa/v1/topdown/cache"
 	"github.com/open-policy-agent/opa/v1/topdown/print"
@@ -34,6 +35,17 @@ type EvalContext interface {
 type PrepareQueryOpts struct {
 	Opts        []func(*rego.Rego)
 	PrepareOpts []rego.PrepareOption
+}
+
+func newEvaluatedRuleTracker() *topdown.EvaluatedRuleTracker {
+	return &topdown.EvaluatedRuleTracker{}
+}
+
+func evaluatedRuleLabels(t *topdown.EvaluatedRuleTracker) []map[string]any {
+	if t == nil || len(t.Labels) == 0 {
+		return nil
+	}
+	return t.Labels
 }
 
 // Eval - Evaluates an input against a provided EvalContext and yields result
@@ -64,7 +76,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 			"txn":   result.TxnID,
 		}).Debug("Executing policy query.")
 	}
-
+	tracker := newEvaluatedRuleTracker()
 	pq, err := evalContext.CreatePreparedQueryOnce(
 		PrepareQueryOpts{
 			Opts: []func(*rego.Rego){
@@ -98,6 +110,7 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 			rego.EvalInterQueryBuiltinValueCache(evalContext.InterQueryBuiltinValueCache()),
 			rego.EvalPrintHook(&ph),
 			rego.EvalNDBuiltinCache(ndbCache),
+			rego.EvalEvaluatedRuleTracker(tracker),
 		},
 		evalOpts...,
 	)
@@ -119,6 +132,8 @@ func Eval(ctx context.Context, evalContext EvalContext, input ast.Value, result 
 
 	result.NDBuiltinCache = ndbCache
 	result.Decision = rs[0].Expressions[0].Value
+
+	result.EvaluatedRuleLabels = evaluatedRuleLabels(tracker)
 
 	return err
 }

--- a/envoyauth/evaluation_test.go
+++ b/envoyauth/evaluation_test.go
@@ -2,6 +2,7 @@ package envoyauth
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -51,6 +52,17 @@ func TestEval(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	expectedLabels := []map[string]any{
+		{
+			"service":  "authz",
+			"severity": "low",
+			"team":     "platform",
+		},
+	}
+	if !reflect.DeepEqual(expectedLabels, res.EvaluatedRuleLabels) {
+		t.Errorf("expected evaluated rule labels %v, got %v", expectedLabels, res.EvaluatedRuleLabels)
+	}
+
 	logs := logger.Entries()
 	if exp, act := 3, len(logs); exp != act {
 		t.Fatalf("expected %d logs, got %d: %v", exp, act, logs)
@@ -70,7 +82,7 @@ func TestEval(t *testing.T) {
 	if exp, act := logging.Info, logs[2].Level; exp != act {
 		t.Errorf("expected log level info, got %d", act)
 	}
-	if exp, act := `example.rego:9: {"firstname": "foo", "lastname": "bar"}`, logs[2].Message; exp != act {
+	if exp, act := `example.rego:17: {"firstname": "foo", "lastname": "bar"}`, logs[2].Message; exp != act {
 		t.Errorf("expected log message %q, got %q", exp, act)
 	}
 	if exp, act := res.DecisionID, logs[2].Fields["decision-id"]; exp != act {
@@ -112,16 +124,24 @@ func TestEval(t *testing.T) {
 
 func testAuthzServer(logger logging.Logger) (*mockExtAuthzGrpcServer, error) {
 
-	module := `
-		package envoy.authz
+	module := `# METADATA
+# scope: package
+# labels:
+#   service: authz
+#   severity: info
+package envoy.authz
 
-		default allow = false
+default allow = false
 
-		allow if {
-			input.parsed_body.firstname == "foo"
-			input.parsed_body.lastname == "bar"
-			print(input.parsed_body)
-		}`
+# METADATA
+# labels:
+#   severity: low
+#   team: platform
+allow if {
+	input.parsed_body.firstname == "foo"
+	input.parsed_body.lastname == "bar"
+	print(input.parsed_body)
+}`
 
 	ctx := context.Background()
 	store := inmem.New()
@@ -136,6 +156,7 @@ func testAuthzServer(logger logging.Logger) (*mockExtAuthzGrpcServer, error) {
 	m, err := plugins.New([]byte{}, "test", store,
 		plugins.EnablePrintStatements(true),
 		plugins.Logger(logger),
+		plugins.WithParserOptions(ast.ParserOptions{ProcessAnnotation: true}),
 	)
 	if err != nil {
 		return nil, err

--- a/envoyauth/response.go
+++ b/envoyauth/response.go
@@ -21,14 +21,15 @@ import (
 
 // EvalResult - Captures the result from evaluating a query against an input
 type EvalResult struct {
-	Revision       string // Deprecated: Use `revisions` instead.
-	Revisions      map[string]string
-	DecisionID     string
-	TxnID          uint64
-	Decision       any
-	Metrics        metrics.Metrics
-	Txn            storage.Transaction
-	NDBuiltinCache builtins.NDBCache
+	Revision            string // Deprecated: Use `revisions` instead.
+	Revisions           map[string]string
+	DecisionID          string
+	TxnID               uint64
+	Decision            any
+	Metrics             metrics.Metrics
+	Txn                 storage.Transaction
+	EvaluatedRuleLabels []map[string]any
+	NDBuiltinCache      builtins.NDBCache
 }
 
 // StopFunc should be called as soon as the evaluation is finished

--- a/opa/decisionlog/decision_log.go
+++ b/opa/decisionlog/decision_log.go
@@ -28,10 +28,10 @@ func LogDecision(ctx context.Context, plugin *logs.Plugin, info *server.Info, re
 		bundles[name] = server.BundleInfo{Revision: rev}
 	}
 	info.Bundles = bundles
-
 	info.DecisionID = result.DecisionID
 	info.Metrics = result.Metrics
 	info.Txn = result.Txn
+	info.EvaluatedRuleLabels = result.EvaluatedRuleLabels
 
 	if err != nil {
 		switch err.(type) {


### PR DESCRIPTION
OPA 1.17.* introduced metadata labels in decision logs. This wires in support.