### PR TITLE
workflows: take go version from OPA

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,6 +16,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+
       - name: Build Golang
         run: make ci-go-build
         timeout-minutes: 15
@@ -27,6 +37,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+
       - name: Unit Test Golang
         run: make ci-go-test
         timeout-minutes: 15
@@ -37,6 +57,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
 
       - name: Golang Style and Lint Check
         run: make check
@@ -52,6 +82,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+
       - name: Build and Push
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -66,6 +106,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
 
       - name: Build docker image
         run: make ci-go-build ci-go-build-linux-static image-quick tag-latest
@@ -95,6 +145,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
 
       - name: Build docker image
         run: make ci-go-build ci-go-build-linux-static image-quick tag-latest

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -19,6 +19,16 @@ jobs:
         # Subsequent jobs will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
+      - name: Sync Go version from OPA
+        run: |
+          OPA_VERSION=$(go list -m -f '{{.Version}}' github.com/open-policy-agent/opa)
+          curl -fsSL "https://raw.githubusercontent.com/open-policy-agent/opa/${OPA_VERSION}/.go-version" -o .go-version
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+
       - name: Build Release Binaries
         run: make release
 


### PR DESCRIPTION
Now, when we pull in a patch version of OPA that has only changed the Go version used to build it, it'll have the same effect on opa-envoy-plugin.