### PR TITLE
build: bump testsrv golang base image 1.24 -> 1.26

### DIFF
--- a/examples/grpc/testsrv/Dockerfile
+++ b/examples/grpc/testsrv/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.26
 WORKDIR /src
 COPY . /src
 RUN go build .


### PR DESCRIPTION
## What

Bumps the `examples/grpc/testsrv` Docker base image from `golang:1.24` to `golang:1.26`.

## Why

The testsrv example image was the last place still pinned to Go 1.24, while the repo's Go version (`.go-version`, pulled from OPA) is `1.26.5` and the root `go.mod` is already at `go 1.25.0`.

Official `golang` images set `GOTOOLCHAIN=local`, so the container cannot auto-download a newer toolchain. Any bump of the `testsrv/go.mod` `go` directive past 1.24 therefore hard-fails the **Envoy gRPC End-to-End Test** at the `testsrv-image` build step:

```
#9 [4/4] RUN go build .
#9 0.118 go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go build ." did not complete successfully: exit code: 1
make: *** [Makefile:10: testsrv-image] Error 1
```

This is currently blocking #863 (dependabot `golang.org/x/net` 0.48.0 -> 0.55.0), since x/net 0.55.0 requires Go 1.25. Once this merges, #863 should go green after a rebase.
